### PR TITLE
chore: update OCI image references

### DIFF
--- a/nix/_dockerfiles/pins/docker_io_nextcloud/linux_amd64/31/Dockerfile
+++ b/nix/_dockerfiles/pins/docker_io_nextcloud/linux_amd64/31/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/amd64 docker.io/nextcloud:31

--- a/nix/_dockerfiles/pins/docker_io_nextcloud/linux_amd64/31_0/Dockerfile
+++ b/nix/_dockerfiles/pins/docker_io_nextcloud/linux_amd64/31_0/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/amd64 docker.io/nextcloud:31.0

--- a/nix/_dockerfiles/pins/docker_io_nextcloud/linux_arm64/31/Dockerfile
+++ b/nix/_dockerfiles/pins/docker_io_nextcloud/linux_arm64/31/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/arm64 docker.io/nextcloud:31

--- a/nix/_dockerfiles/pins/docker_io_nextcloud/linux_arm64/31_0/Dockerfile
+++ b/nix/_dockerfiles/pins/docker_io_nextcloud/linux_arm64/31_0/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/arm64 docker.io/nextcloud:31.0


### PR DESCRIPTION
## Automated OCI Image Update
  
  This PR contains automated updates to OCI image references:
  
  - Version Dockerfiles generated from `images.json`
  - Pin Dockerfiles created from version tags
  - Updated `digests.json` with latest image references
  
  ### Commits
  
  ```
  bd8dc58 chore: generate pin Dockerfiles from version tags
  ```
  
  This PR will be automatically merged by Mergify if all checks pass.