### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -35,8 +35,8 @@
   },
   "docker.io/nextcloud": {
     "30": {
-      "linux/amd64": "docker.io/nextcloud:30@sha256:72f5e25d6f0ea3c57b9b28aa318793187edfe6d87c0de04e84600933643f3f81",
-      "linux/arm64": "docker.io/nextcloud:30@sha256:72f5e25d6f0ea3c57b9b28aa318793187edfe6d87c0de04e84600933643f3f81"
+      "linux/amd64": "docker.io/nextcloud:30@sha256:7391d58d2dbf857ed3413bf2badce0df710d789ce66cdb051a3f500c9b05f32a",
+      "linux/arm64": "docker.io/nextcloud:30@sha256:7391d58d2dbf857ed3413bf2badce0df710d789ce66cdb051a3f500c9b05f32a"
     },
     "30.0": {
       "linux/amd64": "docker.io/nextcloud:30.0@sha256:72f5e25d6f0ea3c57b9b28aa318793187edfe6d87c0de04e84600933643f3f81",


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    f25f0ae chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.