### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -25,8 +25,8 @@
       "linux/arm64": "docker.io/n8nio/n8n:1.107.0@sha256:5cf377fa49b134faede040f3ed2262e256a25dda54798be6445203fdd0efaaf9"
     },
     "nightly": {
-      "linux/amd64": "docker.io/n8nio/n8n:nightly@sha256:dcf3d275ffb45e6552f7c4cd27733921aac7bd9ab8b283f5e04e838f7a1932c1",
-      "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:dcf3d275ffb45e6552f7c4cd27733921aac7bd9ab8b283f5e04e838f7a1932c1"
+      "linux/amd64": "docker.io/n8nio/n8n:nightly@sha256:c779755d4a33d037df8d3f69fd61c540f6e29440bea18ff977b267fca6bcc54c",
+      "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:c779755d4a33d037df8d3f69fd61c540f6e29440bea18ff977b267fca6bcc54c"
     },
     "stable": {
       "linux/amd64": "docker.io/n8nio/n8n:stable@sha256:d4ac379e8c0148c55b654c437fe4b8c9e7e77a36fd4ae5585511ec4974805ab1",


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    30ef3ed chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.