### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -39,12 +39,12 @@
       "linux/arm64": "docker.io/nextcloud:30@sha256:2e0e0c270e97abd9559cb3216ec85859284c1151aff226e731fba6216f7e5c78"
     },
     "30.0": {
-      "linux/amd64": "docker.io/nextcloud:30.0@sha256:c7374a17773452f6064d23af7059f7c4741a6f0ca4c0a193c10b3557d64afed6",
-      "linux/arm64": "docker.io/nextcloud:30.0@sha256:c7374a17773452f6064d23af7059f7c4741a6f0ca4c0a193c10b3557d64afed6"
+      "linux/amd64": "docker.io/nextcloud:30.0@sha256:2e0e0c270e97abd9559cb3216ec85859284c1151aff226e731fba6216f7e5c78",
+      "linux/arm64": "docker.io/nextcloud:30.0@sha256:2e0e0c270e97abd9559cb3216ec85859284c1151aff226e731fba6216f7e5c78"
     },
     "31": {
-      "linux/amd64": "docker.io/nextcloud:31@sha256:c256cdcf6f27d17c818a1b877d48fbd21f62059f5245e2507316f0941e79ea1c",
-      "linux/arm64": "docker.io/nextcloud:31@sha256:c256cdcf6f27d17c818a1b877d48fbd21f62059f5245e2507316f0941e79ea1c"
+      "linux/amd64": "docker.io/nextcloud:31@sha256:4bd3671cdc26122bbc1e06785c65cae80404b1f525c37f4f2c13b08073beb270",
+      "linux/arm64": "docker.io/nextcloud:31@sha256:4bd3671cdc26122bbc1e06785c65cae80404b1f525c37f4f2c13b08073beb270"
     },
     "31.0": {
       "linux/amd64": "docker.io/nextcloud:31.0@sha256:c256cdcf6f27d17c818a1b877d48fbd21f62059f5245e2507316f0941e79ea1c",


### PR DESCRIPTION
## Automated OCI Image Update
  
  This PR contains automated updates to OCI image references:
  
  - Version Dockerfiles generated from `images.json`
  - Pin Dockerfiles created from version tags
  - Updated `digests.json` with latest image references
  
  ### Commits
  
  ```
  a53a3bc chore: update digests.json with latest image references
  ```
  
  This PR will be automatically merged by Mergify if all checks pass.