### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -47,8 +47,8 @@
       "linux/arm64": "docker.io/nextcloud:31@sha256:4bd3671cdc26122bbc1e06785c65cae80404b1f525c37f4f2c13b08073beb270"
     },
     "31.0": {
-      "linux/amd64": "docker.io/nextcloud:31.0@sha256:c256cdcf6f27d17c818a1b877d48fbd21f62059f5245e2507316f0941e79ea1c",
-      "linux/arm64": "docker.io/nextcloud:31.0@sha256:c256cdcf6f27d17c818a1b877d48fbd21f62059f5245e2507316f0941e79ea1c"
+      "linux/amd64": "docker.io/nextcloud:31.0@sha256:4bd3671cdc26122bbc1e06785c65cae80404b1f525c37f4f2c13b08073beb270",
+      "linux/arm64": "docker.io/nextcloud:31.0@sha256:4bd3671cdc26122bbc1e06785c65cae80404b1f525c37f4f2c13b08073beb270"
     }
   },
   "docker.io/plexinc/pms-docker": {


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    8070e59 chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.