### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -24,6 +24,10 @@
       "linux/amd64": "docker.io/n8nio/n8n:1.107.0@sha256:5cf377fa49b134faede040f3ed2262e256a25dda54798be6445203fdd0efaaf9",
       "linux/arm64": "docker.io/n8nio/n8n:1.107.0@sha256:5cf377fa49b134faede040f3ed2262e256a25dda54798be6445203fdd0efaaf9"
     },
+    "1.107.1": {
+      "linux/amd64": "docker.io/n8nio/n8n:1.107.1@sha256:7e3ffa822325e631792ae9787ddf7d5dbd73eeb78acd28b357f1324de0aec3ba",
+      "linux/arm64": "docker.io/n8nio/n8n:1.107.1@sha256:7e3ffa822325e631792ae9787ddf7d5dbd73eeb78acd28b357f1324de0aec3ba"
+    },
     "nightly": {
       "linux/amd64": "docker.io/n8nio/n8n:nightly@sha256:c779755d4a33d037df8d3f69fd61c540f6e29440bea18ff977b267fca6bcc54c",
       "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:c779755d4a33d037df8d3f69fd61c540f6e29440bea18ff977b267fca6bcc54c"


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    f29a2b8 chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.