### PR TITLE
chore: update OCI image references

### DIFF
--- a/nix/_dockerfiles/pins/docker_io_plexinc_pms-docker/linux_amd64/latest/Dockerfile
+++ b/nix/_dockerfiles/pins/docker_io_plexinc_pms-docker/linux_amd64/latest/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/amd64 docker.io/plexinc/pms-docker:latest

--- a/nix/_dockerfiles/pins/docker_io_plexinc_pms-docker/linux_arm64/latest/Dockerfile
+++ b/nix/_dockerfiles/pins/docker_io_plexinc_pms-docker/linux_arm64/latest/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/arm64 docker.io/plexinc/pms-docker:latest


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    11b4a37 chore: generate pin Dockerfiles from version tags
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.