### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -47,12 +47,12 @@
       "linux/arm64": "docker.io/nextcloud:30.0@sha256:8ecf038d504029a428f82c4df6fe182cb56f706baa96d6b39e8ab310af3f57ba"
     },
     "31": {
-      "linux/amd64": "docker.io/nextcloud:31@sha256:dac4be4c94aa71f20c0fbdc6b285f5aabcaf93b2e891dc8919d317b122101177",
-      "linux/arm64": "docker.io/nextcloud:31@sha256:dac4be4c94aa71f20c0fbdc6b285f5aabcaf93b2e891dc8919d317b122101177"
+      "linux/amd64": "docker.io/nextcloud:31@sha256:25b7e083b03acf9e9bf1176212235ca086c865e64f03dd076ea92235a8615518",
+      "linux/arm64": "docker.io/nextcloud:31@sha256:25b7e083b03acf9e9bf1176212235ca086c865e64f03dd076ea92235a8615518"
     },
     "31.0": {
-      "linux/amd64": "docker.io/nextcloud:31.0@sha256:dac4be4c94aa71f20c0fbdc6b285f5aabcaf93b2e891dc8919d317b122101177",
-      "linux/arm64": "docker.io/nextcloud:31.0@sha256:dac4be4c94aa71f20c0fbdc6b285f5aabcaf93b2e891dc8919d317b122101177"
+      "linux/amd64": "docker.io/nextcloud:31.0@sha256:25b7e083b03acf9e9bf1176212235ca086c865e64f03dd076ea92235a8615518",
+      "linux/arm64": "docker.io/nextcloud:31.0@sha256:25b7e083b03acf9e9bf1176212235ca086c865e64f03dd076ea92235a8615518"
     }
   },
   "docker.io/plexinc/pms-docker": {


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    f280a23 chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.