### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -7,6 +7,10 @@
     "2025.8.1": {
       "linux/amd64": "docker.io/homeassistant/home-assistant:2025.8.1@sha256:b064da094630c87b97a3b4ac2750a6ee13b251d0b301c8824bb168d57bc12cd0",
       "linux/arm64": "docker.io/homeassistant/home-assistant:2025.8.1@sha256:b064da094630c87b97a3b4ac2750a6ee13b251d0b301c8824bb168d57bc12cd0"
+    },
+    "2025.8.2": {
+      "linux/amd64": "docker.io/homeassistant/home-assistant:2025.8.2@sha256:cd742b4b3311c7e84a978448860088e734221e9314b73e3931d148d1b081a263",
+      "linux/arm64": "docker.io/homeassistant/home-assistant:2025.8.2@sha256:cd742b4b3311c7e84a978448860088e734221e9314b73e3931d148d1b081a263"
     }
   },
   "docker.io/jellyfin/jellyfin": {


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    9e7ccdf chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.