### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -114,5 +114,11 @@
       "linux/amd64": "ghcr.io/open-webui/open-webui:main-ollama@sha256:0056407a7801c42693c7297170700d4e9ed30195b48fa5067a75bb83a56754f8",
       "linux/arm64": "ghcr.io/open-webui/open-webui:main-ollama@sha256:0056407a7801c42693c7297170700d4e9ed30195b48fa5067a75bb83a56754f8"
     }
+  },
+  "ghcr.io/paperless-ngx/paperless-ngx": {
+    "2.18.0": {
+      "linux/amd64": "ghcr.io/paperless-ngx/paperless-ngx:2.18.0@sha256:13ef2894816c68672367acb75e896d8eb2ab8057e5059d39ae93f80d49ab8725",
+      "linux/arm64": "ghcr.io/paperless-ngx/paperless-ngx:2.18.0@sha256:13ef2894816c68672367acb75e896d8eb2ab8057e5059d39ae93f80d49ab8725"
+    }
   }
 }


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    cf7f7c7 chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.