### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -37,8 +37,8 @@
       "linux/arm64": "docker.io/n8nio/n8n:1.107.2@sha256:49e155af65aef02cb5dd6d39eed22f6e078b1cd567836bc02c8a1616ee2a6017"
     },
     "nightly": {
-      "linux/amd64": "docker.io/n8nio/n8n:nightly@sha256:83ca3e5855a59032ecab73b6b82391dfaac5f5c364645a13c5a4c54ada8d6e9c",
-      "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:83ca3e5855a59032ecab73b6b82391dfaac5f5c364645a13c5a4c54ada8d6e9c"
+      "linux/amd64": "docker.io/n8nio/n8n:nightly@sha256:19f2a635bfb590ff349a75d6465779f3a2f089a5f55f0513afe2505420398d82",
+      "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:19f2a635bfb590ff349a75d6465779f3a2f089a5f55f0513afe2505420398d82"
     },
     "stable": {
       "linux/amd64": "docker.io/n8nio/n8n:stable@sha256:d4ac379e8c0148c55b654c437fe4b8c9e7e77a36fd4ae5585511ec4974805ab1",


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    d444782 chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.