### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -55,8 +55,8 @@
       "linux/arm64": "docker.io/nextcloud:30.0@sha256:42c052ba750c471ce304728596cf8c3c31eace891c6f55cf7173e3a66098be0b"
     },
     "31": {
-      "linux/amd64": "docker.io/nextcloud:31@sha256:25b7e083b03acf9e9bf1176212235ca086c865e64f03dd076ea92235a8615518",
-      "linux/arm64": "docker.io/nextcloud:31@sha256:25b7e083b03acf9e9bf1176212235ca086c865e64f03dd076ea92235a8615518"
+      "linux/amd64": "docker.io/nextcloud:31@sha256:72abe188e4045026f880e124de5c281c5bbea555b468f68344b3fa97a4dcaa58",
+      "linux/arm64": "docker.io/nextcloud:31@sha256:72abe188e4045026f880e124de5c281c5bbea555b468f68344b3fa97a4dcaa58"
     },
     "31.0": {
       "linux/amd64": "docker.io/nextcloud:31.0@sha256:72abe188e4045026f880e124de5c281c5bbea555b468f68344b3fa97a4dcaa58",


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    f40228e chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.