### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -119,6 +119,10 @@
     "2.18.0": {
       "linux/amd64": "ghcr.io/paperless-ngx/paperless-ngx:2.18.0@sha256:13ef2894816c68672367acb75e896d8eb2ab8057e5059d39ae93f80d49ab8725",
       "linux/arm64": "ghcr.io/paperless-ngx/paperless-ngx:2.18.0@sha256:13ef2894816c68672367acb75e896d8eb2ab8057e5059d39ae93f80d49ab8725"
+    },
+    "2.18.1": {
+      "linux/amd64": "ghcr.io/paperless-ngx/paperless-ngx:2.18.1@sha256:2dbee2d7fea624af8f12877936f6d728f351d2b8f4ddb34bdc06d933f0f47200",
+      "linux/arm64": "ghcr.io/paperless-ngx/paperless-ngx:2.18.1@sha256:2dbee2d7fea624af8f12877936f6d728f351d2b8f4ddb34bdc06d933f0f47200"
     }
   }
 }


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    e7a0a99 chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.