### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -36,6 +36,10 @@
       "linux/amd64": "docker.io/n8nio/n8n:1.107.2@sha256:49e155af65aef02cb5dd6d39eed22f6e078b1cd567836bc02c8a1616ee2a6017",
       "linux/arm64": "docker.io/n8nio/n8n:1.107.2@sha256:49e155af65aef02cb5dd6d39eed22f6e078b1cd567836bc02c8a1616ee2a6017"
     },
+    "1.108.0": {
+      "linux/amd64": "docker.io/n8nio/n8n:1.108.0@sha256:3089b17e7580375d531af63de29e2de10701c1b34f2f750676db440d9b7abb35",
+      "linux/arm64": "docker.io/n8nio/n8n:1.108.0@sha256:3089b17e7580375d531af63de29e2de10701c1b34f2f750676db440d9b7abb35"
+    },
     "nightly": {
       "linux/amd64": "docker.io/n8nio/n8n:nightly@sha256:1061a6053ce0589fe6edcb01c9758f5da528cc83d66951a596a431797cf9839e",
       "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:1061a6053ce0589fe6edcb01c9758f5da528cc83d66951a596a431797cf9839e"


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    2b0781f chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.