### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -91,6 +91,10 @@
     "v1.138.0": {
       "linux/amd64": "ghcr.io/immich-app/immich-server:v1.138.0@sha256:12cee930e2cc211a95acae12ad780c0b2eecaea0479a06e255c73a4deb0b3efb",
       "linux/arm64": "ghcr.io/immich-app/immich-server:v1.138.0@sha256:12cee930e2cc211a95acae12ad780c0b2eecaea0479a06e255c73a4deb0b3efb"
+    },
+    "v1.138.1": {
+      "linux/amd64": "ghcr.io/immich-app/immich-server:v1.138.1@sha256:1d303559b4c7c6b4ea3cea2276279e4cafdf605c624625674924a6ac04f263cb",
+      "linux/arm64": "ghcr.io/immich-app/immich-server:v1.138.1@sha256:1d303559b4c7c6b4ea3cea2276279e4cafdf605c624625674924a6ac04f263cb"
     }
   },
   "ghcr.io/open-webui/open-webui": {


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    d7dc5ca chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.