### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -41,8 +41,8 @@
       "linux/arm64": "docker.io/n8nio/n8n:1.108.0@sha256:3089b17e7580375d531af63de29e2de10701c1b34f2f750676db440d9b7abb35"
     },
     "nightly": {
-      "linux/amd64": "docker.io/n8nio/n8n:nightly@sha256:1061a6053ce0589fe6edcb01c9758f5da528cc83d66951a596a431797cf9839e",
-      "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:1061a6053ce0589fe6edcb01c9758f5da528cc83d66951a596a431797cf9839e"
+      "linux/amd64": "docker.io/n8nio/n8n:nightly@sha256:d2f9d1dd1bd4fde411097a12a751288b78649e9cb244552a0a85a319c25cd02b",
+      "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:d2f9d1dd1bd4fde411097a12a751288b78649e9cb244552a0a85a319c25cd02b"
     },
     "stable": {
       "linux/amd64": "docker.io/n8nio/n8n:stable@sha256:524bd974e19cd5a6972058c601084abb6b1b970d6a39f8bf8bbe05406a2450a1",


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    fa01c95 chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.