### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -45,8 +45,8 @@
       "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:b2848831e2afc08540815a960ea6b92fa65a773ed6424b6b0cf5f3fa62011436"
     },
     "stable": {
-      "linux/amd64": "docker.io/n8nio/n8n:stable@sha256:524bd974e19cd5a6972058c601084abb6b1b970d6a39f8bf8bbe05406a2450a1",
-      "linux/arm64": "docker.io/n8nio/n8n:stable@sha256:524bd974e19cd5a6972058c601084abb6b1b970d6a39f8bf8bbe05406a2450a1"
+      "linux/amd64": "docker.io/n8nio/n8n:stable@sha256:a49bc867def7800e99ec175dee46b62282961a6460cfb422b3adec3e53073d63",
+      "linux/arm64": "docker.io/n8nio/n8n:stable@sha256:a49bc867def7800e99ec175dee46b62282961a6460cfb422b3adec3e53073d63"
     }
   },
   "docker.io/nextcloud": {


### PR DESCRIPTION
## Automated OCI Image Update
  
  This PR contains automated updates to OCI image references:
  
  - Version Dockerfiles generated from `images.json`
  - Pin Dockerfiles created from version tags
  - Updated `digests.json` with latest image references
  
  ### Commits
  
  ```
  5342a2b chore: update digests.json with latest image references
  ```
  
  This PR will be automatically merged by Mergify if all checks pass.