### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -40,6 +40,10 @@
       "linux/amd64": "docker.io/n8nio/n8n:1.108.0@sha256:3089b17e7580375d531af63de29e2de10701c1b34f2f750676db440d9b7abb35",
       "linux/arm64": "docker.io/n8nio/n8n:1.108.0@sha256:3089b17e7580375d531af63de29e2de10701c1b34f2f750676db440d9b7abb35"
     },
+    "1.108.1": {
+      "linux/amd64": "docker.io/n8nio/n8n:1.108.1@sha256:8509288ac9c0591ddb8a4e4a8e432e003f3cc91bf492cfed6e2c8125c3de3a94",
+      "linux/arm64": "docker.io/n8nio/n8n:1.108.1@sha256:8509288ac9c0591ddb8a4e4a8e432e003f3cc91bf492cfed6e2c8125c3de3a94"
+    },
     "nightly": {
       "linux/amd64": "docker.io/n8nio/n8n:nightly@sha256:b2848831e2afc08540815a960ea6b92fa65a773ed6424b6b0cf5f3fa62011436",
       "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:b2848831e2afc08540815a960ea6b92fa65a773ed6424b6b0cf5f3fa62011436"


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    9c9ffdb chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.