### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -45,8 +45,8 @@
       "linux/arm64": "docker.io/n8nio/n8n:1.108.1@sha256:8509288ac9c0591ddb8a4e4a8e432e003f3cc91bf492cfed6e2c8125c3de3a94"
     },
     "nightly": {
-      "linux/amd64": "docker.io/n8nio/n8n:nightly@sha256:b2848831e2afc08540815a960ea6b92fa65a773ed6424b6b0cf5f3fa62011436",
-      "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:b2848831e2afc08540815a960ea6b92fa65a773ed6424b6b0cf5f3fa62011436"
+      "linux/amd64": "docker.io/n8nio/n8n:nightly@sha256:61a7bf5662f2c726f01bc61cc97100a820aa354dc8c32d6b9cb5e5a709b3a829",
+      "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:61a7bf5662f2c726f01bc61cc97100a820aa354dc8c32d6b9cb5e5a709b3a829"
     },
     "stable": {
       "linux/amd64": "docker.io/n8nio/n8n:stable@sha256:a49bc867def7800e99ec175dee46b62282961a6460cfb422b3adec3e53073d63",


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    c1eff36 chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.