### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -107,8 +107,8 @@
       "linux/arm64": "ghcr.io/open-webui/open-webui:0.6@sha256:fb739f0e9cb0b51d66f0c43bab8bab00960dac38804a243aca1323a563add9cd"
     },
     "0.6-ollama": {
-      "linux/amd64": "ghcr.io/open-webui/open-webui:0.6-ollama@sha256:6027586f816fce2260f4afc251a1cf704bcf9f5ce820522768b8fbd643b03745",
-      "linux/arm64": "ghcr.io/open-webui/open-webui:0.6-ollama@sha256:6027586f816fce2260f4afc251a1cf704bcf9f5ce820522768b8fbd643b03745"
+      "linux/amd64": "ghcr.io/open-webui/open-webui:0.6-ollama@sha256:d1790572f0b0e2acd53ac29c0163844b3f4d72f2155c62fff0c7af8d620d3c9b",
+      "linux/arm64": "ghcr.io/open-webui/open-webui:0.6-ollama@sha256:d1790572f0b0e2acd53ac29c0163844b3f4d72f2155c62fff0c7af8d620d3c9b"
     },
     "0.6.22": {
       "linux/amd64": "ghcr.io/open-webui/open-webui:0.6.22@sha256:fb739f0e9cb0b51d66f0c43bab8bab00960dac38804a243aca1323a563add9cd",


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    7cb70d7 chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.