### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -103,8 +103,8 @@
   },
   "ghcr.io/open-webui/open-webui": {
     "0.6": {
-      "linux/amd64": "ghcr.io/open-webui/open-webui:0.6@sha256:fb739f0e9cb0b51d66f0c43bab8bab00960dac38804a243aca1323a563add9cd",
-      "linux/arm64": "ghcr.io/open-webui/open-webui:0.6@sha256:fb739f0e9cb0b51d66f0c43bab8bab00960dac38804a243aca1323a563add9cd"
+      "linux/amd64": "ghcr.io/open-webui/open-webui:0.6@sha256:d5fef0cf1f8acd824b6474e8288526dc02ebe91a66a146eaf1c1c1df657af149",
+      "linux/arm64": "ghcr.io/open-webui/open-webui:0.6@sha256:d5fef0cf1f8acd824b6474e8288526dc02ebe91a66a146eaf1c1c1df657af149"
     },
     "0.6-ollama": {
       "linux/amd64": "ghcr.io/open-webui/open-webui:0.6-ollama@sha256:d1790572f0b0e2acd53ac29c0163844b3f4d72f2155c62fff0c7af8d620d3c9b",
@@ -119,12 +119,12 @@
       "linux/arm64": "ghcr.io/open-webui/open-webui:0.6.22-ollama@sha256:6027586f816fce2260f4afc251a1cf704bcf9f5ce820522768b8fbd643b03745"
     },
     "main": {
-      "linux/amd64": "ghcr.io/open-webui/open-webui:main@sha256:a439e8bcd23a8cc0e9ab742b03f1baecb829281476357b99226e13233e663508",
-      "linux/arm64": "ghcr.io/open-webui/open-webui:main@sha256:a439e8bcd23a8cc0e9ab742b03f1baecb829281476357b99226e13233e663508"
+      "linux/amd64": "ghcr.io/open-webui/open-webui:main@sha256:b101231569b46b326f8badfde103aa570fb97d962140a5ef08ee2603d6458be7",
+      "linux/arm64": "ghcr.io/open-webui/open-webui:main@sha256:b101231569b46b326f8badfde103aa570fb97d962140a5ef08ee2603d6458be7"
     },
     "main-ollama": {
-      "linux/amd64": "ghcr.io/open-webui/open-webui:main-ollama@sha256:0056407a7801c42693c7297170700d4e9ed30195b48fa5067a75bb83a56754f8",
-      "linux/arm64": "ghcr.io/open-webui/open-webui:main-ollama@sha256:0056407a7801c42693c7297170700d4e9ed30195b48fa5067a75bb83a56754f8"
+      "linux/amd64": "ghcr.io/open-webui/open-webui:main-ollama@sha256:1bec8cf5eb59919dc2fc74d9a0ad1ff449efdd713fdf73bd80cdf96db5e8676f",
+      "linux/arm64": "ghcr.io/open-webui/open-webui:main-ollama@sha256:1bec8cf5eb59919dc2fc74d9a0ad1ff449efdd713fdf73bd80cdf96db5e8676f"
     }
   },
   "ghcr.io/paperless-ngx/paperless-ngx": {

--- a/nix/_dockerfiles/pins/docker_io_homeassistant_home-assistant/linux_amd64/2025_8_3/Dockerfile
+++ b/nix/_dockerfiles/pins/docker_io_homeassistant_home-assistant/linux_amd64/2025_8_3/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/amd64 docker.io/homeassistant/home-assistant:2025.8.3

--- a/nix/_dockerfiles/pins/docker_io_homeassistant_home-assistant/linux_arm64/2025_8_3/Dockerfile
+++ b/nix/_dockerfiles/pins/docker_io_homeassistant_home-assistant/linux_arm64/2025_8_3/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/arm64 docker.io/homeassistant/home-assistant:2025.8.3

--- a/nix/_dockerfiles/pins/ghcr_io_open-webui_open-webui/linux_amd64/0_6_23/Dockerfile
+++ b/nix/_dockerfiles/pins/ghcr_io_open-webui_open-webui/linux_amd64/0_6_23/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/amd64 ghcr.io/open-webui/open-webui:0.6.23

--- a/nix/_dockerfiles/pins/ghcr_io_open-webui_open-webui/linux_arm64/0_6_23/Dockerfile
+++ b/nix/_dockerfiles/pins/ghcr_io_open-webui_open-webui/linux_arm64/0_6_23/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/arm64 ghcr.io/open-webui/open-webui:0.6.23


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    91ce62e chore: update digests.json with latest image references
f63e8c9 chore: generate pin Dockerfiles from version tags
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.