### PR TITLE
chore: update OCI image references

### DIFF
--- a/nix/_dockerfiles/pins/docker_io_homeassistant_home-assistant/linux_amd64/2025_8_3/Dockerfile
+++ b/nix/_dockerfiles/pins/docker_io_homeassistant_home-assistant/linux_amd64/2025_8_3/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/amd64 docker.io/homeassistant/home-assistant:2025.8.3

--- a/nix/_dockerfiles/pins/docker_io_homeassistant_home-assistant/linux_arm64/2025_8_3/Dockerfile
+++ b/nix/_dockerfiles/pins/docker_io_homeassistant_home-assistant/linux_arm64/2025_8_3/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/arm64 docker.io/homeassistant/home-assistant:2025.8.3

--- a/nix/_dockerfiles/pins/ghcr_io_open-webui_open-webui/linux_amd64/0_6_23/Dockerfile
+++ b/nix/_dockerfiles/pins/ghcr_io_open-webui_open-webui/linux_amd64/0_6_23/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/amd64 ghcr.io/open-webui/open-webui:0.6.23

--- a/nix/_dockerfiles/pins/ghcr_io_open-webui_open-webui/linux_arm64/0_6_23/Dockerfile
+++ b/nix/_dockerfiles/pins/ghcr_io_open-webui_open-webui/linux_arm64/0_6_23/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/arm64 ghcr.io/open-webui/open-webui:0.6.23


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    73afb36 chore: generate pin Dockerfiles from version tags
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.