### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -127,12 +127,12 @@
       "linux/arm64": "ghcr.io/open-webui/open-webui:0.6.23@sha256:d5fef0cf1f8acd824b6474e8288526dc02ebe91a66a146eaf1c1c1df657af149"
     },
     "main": {
-      "linux/amd64": "ghcr.io/open-webui/open-webui:main@sha256:b101231569b46b326f8badfde103aa570fb97d962140a5ef08ee2603d6458be7",
-      "linux/arm64": "ghcr.io/open-webui/open-webui:main@sha256:b101231569b46b326f8badfde103aa570fb97d962140a5ef08ee2603d6458be7"
+      "linux/amd64": "ghcr.io/open-webui/open-webui:main@sha256:c063df4d87772bbf6b79b94cf9402fab2783b92a81f0f3aa8899b109a2df98ae",
+      "linux/arm64": "ghcr.io/open-webui/open-webui:main@sha256:c063df4d87772bbf6b79b94cf9402fab2783b92a81f0f3aa8899b109a2df98ae"
     },
     "main-ollama": {
-      "linux/amd64": "ghcr.io/open-webui/open-webui:main-ollama@sha256:1bec8cf5eb59919dc2fc74d9a0ad1ff449efdd713fdf73bd80cdf96db5e8676f",
-      "linux/arm64": "ghcr.io/open-webui/open-webui:main-ollama@sha256:1bec8cf5eb59919dc2fc74d9a0ad1ff449efdd713fdf73bd80cdf96db5e8676f"
+      "linux/amd64": "ghcr.io/open-webui/open-webui:main-ollama@sha256:c3712bfe8e4e9a435ddf88cae142a6a7a41230592cfddb641809d3356c37099b",
+      "linux/arm64": "ghcr.io/open-webui/open-webui:main-ollama@sha256:c3712bfe8e4e9a435ddf88cae142a6a7a41230592cfddb641809d3356c37099b"
     }
   },
   "ghcr.io/paperless-ngx/paperless-ngx": {

--- a/nix/_dockerfiles/pins/ghcr_io_open-webui_open-webui/linux_amd64/0_6_24/Dockerfile
+++ b/nix/_dockerfiles/pins/ghcr_io_open-webui_open-webui/linux_amd64/0_6_24/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/amd64 ghcr.io/open-webui/open-webui:0.6.24

--- a/nix/_dockerfiles/pins/ghcr_io_open-webui_open-webui/linux_arm64/0_6_24/Dockerfile
+++ b/nix/_dockerfiles/pins/ghcr_io_open-webui_open-webui/linux_arm64/0_6_24/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/arm64 ghcr.io/open-webui/open-webui:0.6.24


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    8ee561f chore: update digests.json with latest image references
3d1d072 chore: generate pin Dockerfiles from version tags
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.