### PR TITLE
chore: update OCI image references

### DIFF
--- a/nix/_dockerfiles/pins/ghcr_io_open-webui_open-webui/linux_amd64/v0_6_25/Dockerfile
+++ b/nix/_dockerfiles/pins/ghcr_io_open-webui_open-webui/linux_amd64/v0_6_25/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/amd64 ghcr.io/open-webui/open-webui:v0.6.25

--- a/nix/_dockerfiles/pins/ghcr_io_open-webui_open-webui/linux_arm64/v0_6_25/Dockerfile
+++ b/nix/_dockerfiles/pins/ghcr_io_open-webui_open-webui/linux_arm64/v0_6_25/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/arm64 ghcr.io/open-webui/open-webui:v0.6.25


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    8179ee8 chore: generate pin Dockerfiles from version tags
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.