### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -131,8 +131,8 @@
       "linux/arm64": "ghcr.io/open-webui/open-webui:0.6.24@sha256:f59b723d003a1d5e67152eb4ad50d60b5fca3711c55d8c7acd7ccb4a15b98815"
     },
     "main": {
-      "linux/amd64": "ghcr.io/open-webui/open-webui:main@sha256:c063df4d87772bbf6b79b94cf9402fab2783b92a81f0f3aa8899b109a2df98ae",
-      "linux/arm64": "ghcr.io/open-webui/open-webui:main@sha256:c063df4d87772bbf6b79b94cf9402fab2783b92a81f0f3aa8899b109a2df98ae"
+      "linux/amd64": "ghcr.io/open-webui/open-webui:main@sha256:74a5ee5c453e628c2bcd33a41dfe4dcf62d187fedf4867d6b8a087178cd88aa6",
+      "linux/arm64": "ghcr.io/open-webui/open-webui:main@sha256:74a5ee5c453e628c2bcd33a41dfe4dcf62d187fedf4867d6b8a087178cd88aa6"
     },
     "main-ollama": {
       "linux/amd64": "ghcr.io/open-webui/open-webui:main-ollama@sha256:c3712bfe8e4e9a435ddf88cae142a6a7a41230592cfddb641809d3356c37099b",


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    515037e chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.