### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -155,6 +155,10 @@
     "2.18.1": {
       "linux/amd64": "ghcr.io/paperless-ngx/paperless-ngx:2.18.1@sha256:2dbee2d7fea624af8f12877936f6d728f351d2b8f4ddb34bdc06d933f0f47200",
       "linux/arm64": "ghcr.io/paperless-ngx/paperless-ngx:2.18.1@sha256:2dbee2d7fea624af8f12877936f6d728f351d2b8f4ddb34bdc06d933f0f47200"
+    },
+    "2.18.2": {
+      "linux/amd64": "ghcr.io/paperless-ngx/paperless-ngx:2.18.2@sha256:fbe142ff2e02713740329ebb5981c6bb6fe54f8b4de18e98637c2ff586ea1935",
+      "linux/arm64": "ghcr.io/paperless-ngx/paperless-ngx:2.18.2@sha256:fbe142ff2e02713740329ebb5981c6bb6fe54f8b4de18e98637c2ff586ea1935"
     }
   }
 }


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    a357758 chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.