### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -49,8 +49,8 @@
       "linux/arm64": "docker.io/n8nio/n8n:1.108.1@sha256:8509288ac9c0591ddb8a4e4a8e432e003f3cc91bf492cfed6e2c8125c3de3a94"
     },
     "nightly": {
-      "linux/amd64": "docker.io/n8nio/n8n:nightly@sha256:ff152f6d260b197ddf3f4f30de425f4e93a4609d062f386227286dbd7d3378a6",
-      "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:ff152f6d260b197ddf3f4f30de425f4e93a4609d062f386227286dbd7d3378a6"
+      "linux/amd64": "docker.io/n8nio/n8n:nightly@sha256:c2cdb88dcd33746968aecd4013c8926bcd4e6a11f193605b5756ad7ac8f7b5f8",
+      "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:c2cdb88dcd33746968aecd4013c8926bcd4e6a11f193605b5756ad7ac8f7b5f8"
     },
     "stable": {
       "linux/amd64": "docker.io/n8nio/n8n:stable@sha256:a49bc867def7800e99ec175dee46b62282961a6460cfb422b3adec3e53073d63",


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    29df7fd chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.