### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -49,8 +49,8 @@
       "linux/arm64": "docker.io/n8nio/n8n:1.108.1@sha256:8509288ac9c0591ddb8a4e4a8e432e003f3cc91bf492cfed6e2c8125c3de3a94"
     },
     "nightly": {
-      "linux/amd64": "docker.io/n8nio/n8n:nightly@sha256:237563eeba5de7283b8a3948829be590f2203284f58e35915786c0a74d689526",
-      "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:237563eeba5de7283b8a3948829be590f2203284f58e35915786c0a74d689526"
+      "linux/amd64": "docker.io/n8nio/n8n:nightly@sha256:d0be71af4e66457acfa28a9a6d582c8e015fe61896afafebe068398a1ddf2394",
+      "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:d0be71af4e66457acfa28a9a6d582c8e015fe61896afafebe068398a1ddf2394"
     },
     "stable": {
       "linux/amd64": "docker.io/n8nio/n8n:stable@sha256:0f4f26eba634839a37f20f2240db57f85c7c97d26f75b1182dd4c1c86dd0c041",


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    0417fb2 chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.