### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -49,12 +49,12 @@
       "linux/arm64": "docker.io/n8nio/n8n:1.108.1@sha256:8509288ac9c0591ddb8a4e4a8e432e003f3cc91bf492cfed6e2c8125c3de3a94"
     },
     "nightly": {
-      "linux/amd64": "docker.io/n8nio/n8n:nightly@sha256:d0be71af4e66457acfa28a9a6d582c8e015fe61896afafebe068398a1ddf2394",
-      "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:d0be71af4e66457acfa28a9a6d582c8e015fe61896afafebe068398a1ddf2394"
+      "linux/amd64": "docker.io/n8nio/n8n:nightly@sha256:76ab58e1e74f8f1d969734825971f3a389d894dfb3220313d55ca39ab5b8f66d",
+      "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:76ab58e1e74f8f1d969734825971f3a389d894dfb3220313d55ca39ab5b8f66d"
     },
     "stable": {
-      "linux/amd64": "docker.io/n8nio/n8n:stable@sha256:0f4f26eba634839a37f20f2240db57f85c7c97d26f75b1182dd4c1c86dd0c041",
-      "linux/arm64": "docker.io/n8nio/n8n:stable@sha256:0f4f26eba634839a37f20f2240db57f85c7c97d26f75b1182dd4c1c86dd0c041"
+      "linux/amd64": "docker.io/n8nio/n8n:stable@sha256:be916ce819d5020e10f846b79f756649894e84dc75faf2db30b5ce38d788a711",
+      "linux/arm64": "docker.io/n8nio/n8n:stable@sha256:be916ce819d5020e10f846b79f756649894e84dc75faf2db30b5ce38d788a711"
     }
   },
   "docker.io/nextcloud": {
@@ -117,8 +117,8 @@
       "linux/arm64": "ghcr.io/immich-app/immich-server:v1.139.4@sha256:c3c5eeafa5549e446b5fd71394399178d9c87da1dec5fd9e9a80a5a0f13e9fad"
     },
     "v1.140.1": {
-      "linux/amd64": "ghcr.io/immich-app/immich-server:v1.140.1@sha256:92effed36e8fd55dc46e3f50cf891fd12f8f5429aaf646ef99fee938bb1e38af",
-      "linux/arm64": "ghcr.io/immich-app/immich-server:v1.140.1@sha256:92effed36e8fd55dc46e3f50cf891fd12f8f5429aaf646ef99fee938bb1e38af"
+      "linux/amd64": "ghcr.io/immich-app/immich-server:v1.140.1@sha256:d97aea4b3f59989a79c6adffb39a1a8b95dd27c90a7f79280b1176a6220cf17b",
+      "linux/arm64": "ghcr.io/immich-app/immich-server:v1.140.1@sha256:d97aea4b3f59989a79c6adffb39a1a8b95dd27c90a7f79280b1176a6220cf17b"
     }
   },
   "ghcr.io/open-webui/open-webui": {


### PR DESCRIPTION
## Automated OCI Image Update
  
  This PR contains automated updates to OCI image references:
  
  - Version Dockerfiles generated from `images.json`
  - Pin Dockerfiles created from version tags
  - Updated `digests.json` with latest image references
  
  ### Commits
  
  ```
  6ff2ac6 chore: update digests.json with latest image references
  ```
  
  This PR will be automatically merged by Mergify if all checks pass.