### PR TITLE
chore: update OCI image references

### DIFF
--- a/nix/_dockerfiles/pins/ghcr_io_paperless-ngx_paperless-ngx/linux_amd64/2_18_4/Dockerfile
+++ b/nix/_dockerfiles/pins/ghcr_io_paperless-ngx_paperless-ngx/linux_amd64/2_18_4/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/amd64 ghcr.io/paperless-ngx/paperless-ngx:2.18.4

--- a/nix/_dockerfiles/pins/ghcr_io_paperless-ngx_paperless-ngx/linux_arm64/2_18_4/Dockerfile
+++ b/nix/_dockerfiles/pins/ghcr_io_paperless-ngx_paperless-ngx/linux_arm64/2_18_4/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/arm64 ghcr.io/paperless-ngx/paperless-ngx:2.18.4


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    81ff8d6 chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.