### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -57,8 +57,8 @@
       "linux/arm64": "docker.io/n8nio/n8n:1.108.1@sha256:8509288ac9c0591ddb8a4e4a8e432e003f3cc91bf492cfed6e2c8125c3de3a94"
     },
     "nightly": {
-      "linux/amd64": "docker.io/n8nio/n8n:nightly@sha256:b58182d72ec962b4aa64f99776d7326a59d1d110b32325f7e640cc0c26c54b8c",
-      "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:b58182d72ec962b4aa64f99776d7326a59d1d110b32325f7e640cc0c26c54b8c"
+      "linux/amd64": "docker.io/n8nio/n8n:nightly@sha256:b79d70ec94aab61d7683b4564fec9c305d938b35a3268a3ebc10cabb1697ba23",
+      "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:b79d70ec94aab61d7683b4564fec9c305d938b35a3268a3ebc10cabb1697ba23"
     },
     "stable": {
       "linux/amd64": "docker.io/n8nio/n8n:stable@sha256:be916ce819d5020e10f846b79f756649894e84dc75faf2db30b5ce38d788a711",


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    ae01e49 chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.