### PR TITLE
chore: update OCI image references

### DIFF
--- a/nix/_dockerfiles/pins/ghcr_io_open-webui_open-webui/linux_amd64/0_6_27/Dockerfile
+++ b/nix/_dockerfiles/pins/ghcr_io_open-webui_open-webui/linux_amd64/0_6_27/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/amd64 ghcr.io/open-webui/open-webui:0.6.27

--- a/nix/_dockerfiles/pins/ghcr_io_open-webui_open-webui/linux_arm64/0_6_27/Dockerfile
+++ b/nix/_dockerfiles/pins/ghcr_io_open-webui_open-webui/linux_arm64/0_6_27/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/arm64 ghcr.io/open-webui/open-webui:0.6.27


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    1426ec2 chore: generate pin Dockerfiles from version tags
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.