### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -158,6 +158,10 @@
       "linux/amd64": "ghcr.io/open-webui/open-webui:0.6.24@sha256:f59b723d003a1d5e67152eb4ad50d60b5fca3711c55d8c7acd7ccb4a15b98815",
       "linux/arm64": "ghcr.io/open-webui/open-webui:0.6.24@sha256:f59b723d003a1d5e67152eb4ad50d60b5fca3711c55d8c7acd7ccb4a15b98815"
     },
+    "0.6.27": {
+      "linux/amd64": "ghcr.io/open-webui/open-webui:0.6.27@sha256:2fdd8896464fdf14ea6f85b9ebffbe82b09265d7fdd7c30cbfb39e2a3ca47cdd",
+      "linux/arm64": "ghcr.io/open-webui/open-webui:0.6.27@sha256:2fdd8896464fdf14ea6f85b9ebffbe82b09265d7fdd7c30cbfb39e2a3ca47cdd"
+    },
     "main": {
       "linux/amd64": "ghcr.io/open-webui/open-webui:main@sha256:2964a606181b1db2ce45deff111fe6438f331058154a6ea5e4b01a3070a6630b",
       "linux/arm64": "ghcr.io/open-webui/open-webui:main@sha256:2964a606181b1db2ce45deff111fe6438f331058154a6ea5e4b01a3070a6630b"


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    a343f88 chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.