### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -163,8 +163,8 @@
       "linux/arm64": "ghcr.io/open-webui/open-webui:0.6.27@sha256:2fdd8896464fdf14ea6f85b9ebffbe82b09265d7fdd7c30cbfb39e2a3ca47cdd"
     },
     "main": {
-      "linux/amd64": "ghcr.io/open-webui/open-webui:main@sha256:2964a606181b1db2ce45deff111fe6438f331058154a6ea5e4b01a3070a6630b",
-      "linux/arm64": "ghcr.io/open-webui/open-webui:main@sha256:2964a606181b1db2ce45deff111fe6438f331058154a6ea5e4b01a3070a6630b"
+      "linux/amd64": "ghcr.io/open-webui/open-webui:main@sha256:7210e106168243d0128708b5cc3070acb209d7967762c7ef78f2d4716c9457fe",
+      "linux/arm64": "ghcr.io/open-webui/open-webui:main@sha256:7210e106168243d0128708b5cc3070acb209d7967762c7ef78f2d4716c9457fe"
     },
     "main-ollama": {
       "linux/amd64": "ghcr.io/open-webui/open-webui:main-ollama@sha256:c3712bfe8e4e9a435ddf88cae142a6a7a41230592cfddb641809d3356c37099b",


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    7a0dbce chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.