### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -162,6 +162,10 @@
       "linux/amd64": "ghcr.io/open-webui/open-webui:0.6.27@sha256:2fdd8896464fdf14ea6f85b9ebffbe82b09265d7fdd7c30cbfb39e2a3ca47cdd",
       "linux/arm64": "ghcr.io/open-webui/open-webui:0.6.27@sha256:2fdd8896464fdf14ea6f85b9ebffbe82b09265d7fdd7c30cbfb39e2a3ca47cdd"
     },
+    "0.6.28": {
+      "linux/amd64": "ghcr.io/open-webui/open-webui:0.6.28@sha256:4fe25c664d4d50f98f21594f12b59612bf7f5cabcff8e516c5c8521193d9c498",
+      "linux/arm64": "ghcr.io/open-webui/open-webui:0.6.28@sha256:4fe25c664d4d50f98f21594f12b59612bf7f5cabcff8e516c5c8521193d9c498"
+    },
     "main": {
       "linux/amd64": "ghcr.io/open-webui/open-webui:main@sha256:2e78a2f9f6f62173ae28d2203f3c9bcdadc614023380ebbe903ea9fab772535e",
       "linux/arm64": "ghcr.io/open-webui/open-webui:main@sha256:2e78a2f9f6f62173ae28d2203f3c9bcdadc614023380ebbe903ea9fab772535e"


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    2c4dc60 chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.