### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -57,8 +57,8 @@
       "linux/arm64": "docker.io/n8nio/n8n:1.108.1@sha256:8509288ac9c0591ddb8a4e4a8e432e003f3cc91bf492cfed6e2c8125c3de3a94"
     },
     "nightly": {
-      "linux/amd64": "docker.io/n8nio/n8n:nightly@sha256:9e2286890c87888212db54a32915fdc1112117770bbaa4444b4a072d5fd978ef",
-      "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:9e2286890c87888212db54a32915fdc1112117770bbaa4444b4a072d5fd978ef"
+      "linux/amd64": "docker.io/n8nio/n8n:nightly@sha256:adc2c6a63038ffd8f5e17b027ffcfcb78d519d39862678999bbfa10676aa177c",
+      "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:adc2c6a63038ffd8f5e17b027ffcfcb78d519d39862678999bbfa10676aa177c"
     },
     "stable": {
       "linux/amd64": "docker.io/n8nio/n8n:stable@sha256:6c0c7650150a3fb0fd30d13160a87b5227963c36c9297b5bda618bcadfcee932",


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    07beb4d chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.