### PR TITLE
chore: update OCI image references

### DIFF
--- a/nix/_dockerfiles/pins/docker_io_homeassistant_home-assistant/linux_amd64/2025_9_3/Dockerfile
+++ b/nix/_dockerfiles/pins/docker_io_homeassistant_home-assistant/linux_amd64/2025_9_3/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/amd64 docker.io/homeassistant/home-assistant:2025.9.3

--- a/nix/_dockerfiles/pins/docker_io_homeassistant_home-assistant/linux_arm64/2025_9_3/Dockerfile
+++ b/nix/_dockerfiles/pins/docker_io_homeassistant_home-assistant/linux_arm64/2025_9_3/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/arm64 docker.io/homeassistant/home-assistant:2025.9.3


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    9b6b328 chore: generate pin Dockerfiles from version tags
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.