### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -27,6 +27,10 @@
     "2025.9.2": {
       "linux/amd64": "docker.io/homeassistant/home-assistant:2025.9.2@sha256:37af5e84627dc6cc4f8ce2de631cca7ee1fc76c908b429b3a8c1ec46f246a5fe",
       "linux/arm64": "docker.io/homeassistant/home-assistant:2025.9.2@sha256:37af5e84627dc6cc4f8ce2de631cca7ee1fc76c908b429b3a8c1ec46f246a5fe"
+    },
+    "2025.9.3": {
+      "linux/amd64": "docker.io/homeassistant/home-assistant:2025.9.3@sha256:2da8dea31821db443a69d822bd0c47972572fc8379a920a8fac730d2072c8ed2",
+      "linux/arm64": "docker.io/homeassistant/home-assistant:2025.9.3@sha256:2da8dea31821db443a69d822bd0c47972572fc8379a920a8fac730d2072c8ed2"
     }
   },
   "docker.io/jellyfin/jellyfin": {


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    5023dce chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.