### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -143,6 +143,10 @@
     "v1.142.0": {
       "linux/amd64": "ghcr.io/immich-app/immich-server:v1.142.0@sha256:29f12a20fd1975c9df06d99a65658cec40bf2357fb597499c32ee50a75f250ea",
       "linux/arm64": "ghcr.io/immich-app/immich-server:v1.142.0@sha256:29f12a20fd1975c9df06d99a65658cec40bf2357fb597499c32ee50a75f250ea"
+    },
+    "v1.142.1": {
+      "linux/amd64": "ghcr.io/immich-app/immich-server:v1.142.1@sha256:06bc7715fa4c4a1641bd0b566c949cd7327f420632b480389fd4d1e70665d046",
+      "linux/arm64": "ghcr.io/immich-app/immich-server:v1.142.1@sha256:06bc7715fa4c4a1641bd0b566c949cd7327f420632b480389fd4d1e70665d046"
     }
   },
   "ghcr.io/open-webui/open-webui": {
@@ -193,6 +197,10 @@
     "v0.6.26": {
       "linux/amd64": "ghcr.io/open-webui/open-webui:v0.6.26@sha256:3121ba5f8526bcc7f4ff387d0fc8a9caab54f84c4a6fb552b634575d10b1582b",
       "linux/arm64": "ghcr.io/open-webui/open-webui:v0.6.26@sha256:3121ba5f8526bcc7f4ff387d0fc8a9caab54f84c4a6fb552b634575d10b1582b"
+    },
+    "v0.6.30": {
+      "linux/amd64": "ghcr.io/open-webui/open-webui:v0.6.30@sha256:b9f7930a5eea6a3284f45ab6d20f9e1e02a5cd6da6b57b962b05422de5233f23",
+      "linux/arm64": "ghcr.io/open-webui/open-webui:v0.6.30@sha256:b9f7930a5eea6a3284f45ab6d20f9e1e02a5cd6da6b57b962b05422de5233f23"
     }
   },
   "ghcr.io/paperless-ngx/paperless-ngx": {


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    7644da7 chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.