### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -65,8 +65,8 @@
       "linux/arm64": "docker.io/n8nio/n8n:1.108.1@sha256:8509288ac9c0591ddb8a4e4a8e432e003f3cc91bf492cfed6e2c8125c3de3a94"
     },
     "nightly": {
-      "linux/amd64": "docker.io/n8nio/n8n:nightly@sha256:d2d67a5684db5b526967a5f2187310ee12691fb219f03eeadb82b3559a0921ef",
-      "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:d2d67a5684db5b526967a5f2187310ee12691fb219f03eeadb82b3559a0921ef"
+      "linux/amd64": "docker.io/n8nio/n8n:nightly@sha256:a37020cd4e85079c47222f89262103fa1b843c89e2c87739b7efa37e019c71ae",
+      "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:a37020cd4e85079c47222f89262103fa1b843c89e2c87739b7efa37e019c71ae"
     },
     "stable": {
       "linux/amd64": "docker.io/n8nio/n8n:stable@sha256:8c99deed73dbb7f7b32c49f328015fe8322129a9dcf0459a10c4398af255083f",


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    dcc6443 chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.