### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -69,8 +69,8 @@
       "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:a37020cd4e85079c47222f89262103fa1b843c89e2c87739b7efa37e019c71ae"
     },
     "stable": {
-      "linux/amd64": "docker.io/n8nio/n8n:stable@sha256:8c99deed73dbb7f7b32c49f328015fe8322129a9dcf0459a10c4398af255083f",
-      "linux/arm64": "docker.io/n8nio/n8n:stable@sha256:8c99deed73dbb7f7b32c49f328015fe8322129a9dcf0459a10c4398af255083f"
+      "linux/amd64": "docker.io/n8nio/n8n:stable@sha256:d055b7a9ea7da77fbcac60f17ba8517657648b0915a36dde818e44892a718964",
+      "linux/arm64": "docker.io/n8nio/n8n:stable@sha256:d055b7a9ea7da77fbcac60f17ba8517657648b0915a36dde818e44892a718964"
     }
   },
   "docker.io/nextcloud": {


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    39d1446 chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.