### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -31,6 +31,10 @@
     "2025.9.3": {
       "linux/amd64": "docker.io/homeassistant/home-assistant:2025.9.3@sha256:2da8dea31821db443a69d822bd0c47972572fc8379a920a8fac730d2072c8ed2",
       "linux/arm64": "docker.io/homeassistant/home-assistant:2025.9.3@sha256:2da8dea31821db443a69d822bd0c47972572fc8379a920a8fac730d2072c8ed2"
+    },
+    "2025.9.4": {
+      "linux/amd64": "docker.io/homeassistant/home-assistant:2025.9.4@sha256:89ec0583c7f47c8a150204f6b5ed48b5432026012bebe1226cf72775a795a5e1",
+      "linux/arm64": "docker.io/homeassistant/home-assistant:2025.9.4@sha256:89ec0583c7f47c8a150204f6b5ed48b5432026012bebe1226cf72775a795a5e1"
     }
   },
   "docker.io/jellyfin/jellyfin": {


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    9927832 chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.