### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -73,8 +73,8 @@
       "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:5781312d53ca06ea0ef5e0c751b87856f0dce1da825b0d6ab62da74993f37999"
     },
     "stable": {
-      "linux/amd64": "docker.io/n8nio/n8n:stable@sha256:d055b7a9ea7da77fbcac60f17ba8517657648b0915a36dde818e44892a718964",
-      "linux/arm64": "docker.io/n8nio/n8n:stable@sha256:d055b7a9ea7da77fbcac60f17ba8517657648b0915a36dde818e44892a718964"
+      "linux/amd64": "docker.io/n8nio/n8n:stable@sha256:c5fe3ff0b79f7831dc21f9c709bdb7eee4fff4453a28ce84c8e9fa5b9f562686",
+      "linux/arm64": "docker.io/n8nio/n8n:stable@sha256:c5fe3ff0b79f7831dc21f9c709bdb7eee4fff4453a28ce84c8e9fa5b9f562686"
     }
   },
   "docker.io/nextcloud": {


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    7aa9d29 chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.