### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -163,12 +163,12 @@
   },
   "ghcr.io/open-webui/open-webui": {
     "0.6": {
-      "linux/amd64": "ghcr.io/open-webui/open-webui:0.6@sha256:b9f7930a5eea6a3284f45ab6d20f9e1e02a5cd6da6b57b962b05422de5233f23",
-      "linux/arm64": "ghcr.io/open-webui/open-webui:0.6@sha256:b9f7930a5eea6a3284f45ab6d20f9e1e02a5cd6da6b57b962b05422de5233f23"
+      "linux/amd64": "ghcr.io/open-webui/open-webui:0.6@sha256:807a4e918d5ffddebc5ac6ff1b9c0966162be366691852d3b96983305b43fd5e",
+      "linux/arm64": "ghcr.io/open-webui/open-webui:0.6@sha256:807a4e918d5ffddebc5ac6ff1b9c0966162be366691852d3b96983305b43fd5e"
     },
     "0.6-ollama": {
-      "linux/amd64": "ghcr.io/open-webui/open-webui:0.6-ollama@sha256:231d59a988fa0f31c156be9f18df83712b50b17a30485daa70cee46929bbebb4",
-      "linux/arm64": "ghcr.io/open-webui/open-webui:0.6-ollama@sha256:231d59a988fa0f31c156be9f18df83712b50b17a30485daa70cee46929bbebb4"
+      "linux/amd64": "ghcr.io/open-webui/open-webui:0.6-ollama@sha256:f3ea5707bd29e4cb59057c17154f3c5ca213b086dda26a13bdeeaeb54f85c3ed",
+      "linux/arm64": "ghcr.io/open-webui/open-webui:0.6-ollama@sha256:f3ea5707bd29e4cb59057c17154f3c5ca213b086dda26a13bdeeaeb54f85c3ed"
     },
     "0.6.22": {
       "linux/amd64": "ghcr.io/open-webui/open-webui:0.6.22@sha256:fb739f0e9cb0b51d66f0c43bab8bab00960dac38804a243aca1323a563add9cd",
@@ -195,8 +195,8 @@
       "linux/arm64": "ghcr.io/open-webui/open-webui:0.6.28@sha256:4fe25c664d4d50f98f21594f12b59612bf7f5cabcff8e516c5c8521193d9c498"
     },
     "main": {
-      "linux/amd64": "ghcr.io/open-webui/open-webui:main@sha256:05aaa81eb4094038a16f0ae056342e3515d1912a30e41b828bfd3731fbe36a6c",
-      "linux/arm64": "ghcr.io/open-webui/open-webui:main@sha256:05aaa81eb4094038a16f0ae056342e3515d1912a30e41b828bfd3731fbe36a6c"
+      "linux/amd64": "ghcr.io/open-webui/open-webui:main@sha256:5c75d3cc7ff9c199c07e157ae7710370e2b698979a70a64639ead03b7cf4c679",
+      "linux/arm64": "ghcr.io/open-webui/open-webui:main@sha256:5c75d3cc7ff9c199c07e157ae7710370e2b698979a70a64639ead03b7cf4c679"
     },
     "main-ollama": {
       "linux/amd64": "ghcr.io/open-webui/open-webui:main-ollama@sha256:c3712bfe8e4e9a435ddf88cae142a6a7a41230592cfddb641809d3356c37099b",


### PR DESCRIPTION
## Automated OCI Image Update
  
  This PR contains automated updates to OCI image references:
  
  - Version Dockerfiles generated from `images.json`
  - Pin Dockerfiles created from version tags
  - Updated `digests.json` with latest image references
  
  ### Commits
  
  ```
  11e68f2 chore: update digests.json with latest image references
  ```
  
  This PR will be automatically merged by Mergify if all checks pass.