### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -79,20 +79,20 @@
   },
   "docker.io/nextcloud": {
     "30": {
-      "linux/amd64": "docker.io/nextcloud:30@sha256:fbe88436f15b7a49630f40cfa60ec30a72a451fb50307b9b75f877a7ea59e032",
-      "linux/arm64": "docker.io/nextcloud:30@sha256:fbe88436f15b7a49630f40cfa60ec30a72a451fb50307b9b75f877a7ea59e032"
+      "linux/amd64": "docker.io/nextcloud:30@sha256:05578ff5e0f87ff48fc00f9855e3e61733f89f9932dffebff1145a5a898637b2",
+      "linux/arm64": "docker.io/nextcloud:30@sha256:05578ff5e0f87ff48fc00f9855e3e61733f89f9932dffebff1145a5a898637b2"
     },
     "30.0": {
-      "linux/amd64": "docker.io/nextcloud:30.0@sha256:fbe88436f15b7a49630f40cfa60ec30a72a451fb50307b9b75f877a7ea59e032",
-      "linux/arm64": "docker.io/nextcloud:30.0@sha256:fbe88436f15b7a49630f40cfa60ec30a72a451fb50307b9b75f877a7ea59e032"
+      "linux/amd64": "docker.io/nextcloud:30.0@sha256:05578ff5e0f87ff48fc00f9855e3e61733f89f9932dffebff1145a5a898637b2",
+      "linux/arm64": "docker.io/nextcloud:30.0@sha256:05578ff5e0f87ff48fc00f9855e3e61733f89f9932dffebff1145a5a898637b2"
     },
     "31": {
-      "linux/amd64": "docker.io/nextcloud:31@sha256:97c7c1332acf1f936fcadc050d68f57db48ec8caab7e6fd88899f3b1101d7c82",
-      "linux/arm64": "docker.io/nextcloud:31@sha256:97c7c1332acf1f936fcadc050d68f57db48ec8caab7e6fd88899f3b1101d7c82"
+      "linux/amd64": "docker.io/nextcloud:31@sha256:875511fe8d307d7b353b9d754080a40cce3291819af1ed03862d541ba4d5c6a6",
+      "linux/arm64": "docker.io/nextcloud:31@sha256:875511fe8d307d7b353b9d754080a40cce3291819af1ed03862d541ba4d5c6a6"
     },
     "31.0": {
-      "linux/amd64": "docker.io/nextcloud:31.0@sha256:97c7c1332acf1f936fcadc050d68f57db48ec8caab7e6fd88899f3b1101d7c82",
-      "linux/arm64": "docker.io/nextcloud:31.0@sha256:97c7c1332acf1f936fcadc050d68f57db48ec8caab7e6fd88899f3b1101d7c82"
+      "linux/amd64": "docker.io/nextcloud:31.0@sha256:875511fe8d307d7b353b9d754080a40cce3291819af1ed03862d541ba4d5c6a6",
+      "linux/arm64": "docker.io/nextcloud:31.0@sha256:875511fe8d307d7b353b9d754080a40cce3291819af1ed03862d541ba4d5c6a6"
     }
   },
   "docker.io/plexinc/pms-docker": {


### PR DESCRIPTION
## Automated OCI Image Update
  
  This PR contains automated updates to OCI image references:
  
  - Version Dockerfiles generated from `images.json`
  - Pin Dockerfiles created from version tags
  - Updated `digests.json` with latest image references
  
  ### Commits
  
  ```
  b10e43a chore: update digests.json with latest image references
  ```
  
  This PR will be automatically merged by Mergify if all checks pass.