### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -194,6 +194,10 @@
       "linux/amd64": "ghcr.io/open-webui/open-webui:0.6.28@sha256:4fe25c664d4d50f98f21594f12b59612bf7f5cabcff8e516c5c8521193d9c498",
       "linux/arm64": "ghcr.io/open-webui/open-webui:0.6.28@sha256:4fe25c664d4d50f98f21594f12b59612bf7f5cabcff8e516c5c8521193d9c498"
     },
+    "0.6.32": {
+      "linux/amd64": "ghcr.io/open-webui/open-webui:0.6.32@sha256:412334cec4b49ed51bfa9a6d28d1fbf3d5622c3ac42f57736e7d5d2bf5f3e94a",
+      "linux/arm64": "ghcr.io/open-webui/open-webui:0.6.32@sha256:412334cec4b49ed51bfa9a6d28d1fbf3d5622c3ac42f57736e7d5d2bf5f3e94a"
+    },
     "main": {
       "linux/amd64": "ghcr.io/open-webui/open-webui:main@sha256:2b382ae46ba32ecb1a916541cdcb08fe1303f940a9e7323a60df28d868bd67f3",
       "linux/arm64": "ghcr.io/open-webui/open-webui:main@sha256:2b382ae46ba32ecb1a916541cdcb08fe1303f940a9e7323a60df28d868bd67f3"


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    9dc2581 chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.