### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -69,8 +69,8 @@
       "linux/arm64": "docker.io/n8nio/n8n:1.108.1@sha256:8509288ac9c0591ddb8a4e4a8e432e003f3cc91bf492cfed6e2c8125c3de3a94"
     },
     "nightly": {
-      "linux/amd64": "docker.io/n8nio/n8n:nightly@sha256:570a1d865d47694677e744cd246b56dd6b666c02377fe42a2f335ae7c4544e02",
-      "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:570a1d865d47694677e744cd246b56dd6b666c02377fe42a2f335ae7c4544e02"
+      "linux/amd64": "docker.io/n8nio/n8n:nightly@sha256:910ffab809cf8168e0cd39fcd711526cc138418d2e7209c34171be6c9731c42a",
+      "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:910ffab809cf8168e0cd39fcd711526cc138418d2e7209c34171be6c9731c42a"
     },
     "stable": {
       "linux/amd64": "docker.io/n8nio/n8n:stable@sha256:57f95a26b1b28527053fba6316d9d046395d9b4da9d0da486e838384a38fcf37",

--- a/nix/_dockerfiles/pins/docker_io_nextcloud/linux_amd64/32/Dockerfile
+++ b/nix/_dockerfiles/pins/docker_io_nextcloud/linux_amd64/32/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/amd64 docker.io/nextcloud:32

--- a/nix/_dockerfiles/pins/docker_io_nextcloud/linux_amd64/32_0/Dockerfile
+++ b/nix/_dockerfiles/pins/docker_io_nextcloud/linux_amd64/32_0/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/amd64 docker.io/nextcloud:32.0

--- a/nix/_dockerfiles/pins/docker_io_nextcloud/linux_arm64/32/Dockerfile
+++ b/nix/_dockerfiles/pins/docker_io_nextcloud/linux_arm64/32/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/arm64 docker.io/nextcloud:32

--- a/nix/_dockerfiles/pins/docker_io_nextcloud/linux_arm64/32_0/Dockerfile
+++ b/nix/_dockerfiles/pins/docker_io_nextcloud/linux_arm64/32_0/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/arm64 docker.io/nextcloud:32.0


### PR DESCRIPTION
## Automated OCI Image Update
  
  This PR contains automated updates to OCI image references:
  
  - Version Dockerfiles generated from `images.json`
  - Pin Dockerfiles created from version tags
  - Updated `digests.json` with latest image references
  
  ### Commits
  
  ```
  c4d82c9 chore: update digests.json with latest image references
d626cf4 chore: generate pin Dockerfiles from version tags
  ```
  
  This PR will be automatically merged by Mergify if all checks pass.