### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -93,6 +93,14 @@
     "31.0": {
       "linux/amd64": "docker.io/nextcloud:31.0@sha256:88fe398340a896eeebfe0a4ba847998ff2c8fbb3d72de354ac1f08bc7b44db18",
       "linux/arm64": "docker.io/nextcloud:31.0@sha256:88fe398340a896eeebfe0a4ba847998ff2c8fbb3d72de354ac1f08bc7b44db18"
+    },
+    "32": {
+      "linux/amd64": "docker.io/nextcloud:32@sha256:a17419d5f38afc5324d705931bbbe32deaa3c395cfd23eb2755944268ee63660",
+      "linux/arm64": "docker.io/nextcloud:32@sha256:a17419d5f38afc5324d705931bbbe32deaa3c395cfd23eb2755944268ee63660"
+    },
+    "32.0": {
+      "linux/amd64": "docker.io/nextcloud:32.0@sha256:a17419d5f38afc5324d705931bbbe32deaa3c395cfd23eb2755944268ee63660",
+      "linux/arm64": "docker.io/nextcloud:32.0@sha256:a17419d5f38afc5324d705931bbbe32deaa3c395cfd23eb2755944268ee63660"
     }
   },
   "docker.io/plexinc/pms-docker": {


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    e46c9be chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.