### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -69,8 +69,8 @@
       "linux/arm64": "docker.io/n8nio/n8n:1.108.1@sha256:8509288ac9c0591ddb8a4e4a8e432e003f3cc91bf492cfed6e2c8125c3de3a94"
     },
     "nightly": {
-      "linux/amd64": "docker.io/n8nio/n8n:nightly@sha256:910ffab809cf8168e0cd39fcd711526cc138418d2e7209c34171be6c9731c42a",
-      "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:910ffab809cf8168e0cd39fcd711526cc138418d2e7209c34171be6c9731c42a"
+      "linux/amd64": "docker.io/n8nio/n8n:nightly@sha256:8d5caabe9f0619036ef423551258d4f6b5f53f496c18f69689887601827a3d88",
+      "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:8d5caabe9f0619036ef423551258d4f6b5f53f496c18f69689887601827a3d88"
     },
     "stable": {
       "linux/amd64": "docker.io/n8nio/n8n:stable@sha256:57f95a26b1b28527053fba6316d9d046395d9b4da9d0da486e838384a38fcf37",


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    97d8362 chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.