### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -107,8 +107,8 @@
       "linux/arm64": "docker.io/nextcloud:32@sha256:f4d0a4a74e93780db5e2130cdf08caa4cd856f6db4da34802d542d57443a9a63"
     },
     "32.0": {
-      "linux/amd64": "docker.io/nextcloud:32.0@sha256:5413182349f878ed178874d72d028e6140eca7b9a8a8fe04ae3072adce9f23d8",
-      "linux/arm64": "docker.io/nextcloud:32.0@sha256:5413182349f878ed178874d72d028e6140eca7b9a8a8fe04ae3072adce9f23d8"
+      "linux/amd64": "docker.io/nextcloud:32.0@sha256:f4d0a4a74e93780db5e2130cdf08caa4cd856f6db4da34802d542d57443a9a63",
+      "linux/arm64": "docker.io/nextcloud:32.0@sha256:f4d0a4a74e93780db5e2130cdf08caa4cd856f6db4da34802d542d57443a9a63"
     }
   },
   "docker.io/plexinc/pms-docker": {


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    65aacbb chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.