### PR TITLE
chore: update OCI image references

### DIFF
--- a/nix/_dockerfiles/pins/ghcr_io_immich-app_immich-server/linux_amd64/v2_0_0/Dockerfile
+++ b/nix/_dockerfiles/pins/ghcr_io_immich-app_immich-server/linux_amd64/v2_0_0/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/amd64 ghcr.io/immich-app/immich-server:v2.0.0

--- a/nix/_dockerfiles/pins/ghcr_io_immich-app_immich-server/linux_arm64/v2_0_0/Dockerfile
+++ b/nix/_dockerfiles/pins/ghcr_io_immich-app_immich-server/linux_arm64/v2_0_0/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/arm64 ghcr.io/immich-app/immich-server:v2.0.0


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    6ec76a3 chore: generate pin Dockerfiles from version tags
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.