### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -1,8 +1,8 @@
 {
   "docker.io/homeassistant/home-assistant": {
     "2025.10": {
-      "linux/amd64": "docker.io/homeassistant/home-assistant:2025.10@sha256:ae0e2a2f03822c49a0c506bc40e367b4abc8b3207d67a6e0312b42d60867c5e5",
-      "linux/arm64": "docker.io/homeassistant/home-assistant:2025.10@sha256:ae0e2a2f03822c49a0c506bc40e367b4abc8b3207d67a6e0312b42d60867c5e5"
+      "linux/amd64": "docker.io/homeassistant/home-assistant:2025.10@sha256:9255033272ab8f7bede246109ea9e7302527faf3accbf2ba7ef619e2206107ad",
+      "linux/arm64": "docker.io/homeassistant/home-assistant:2025.10@sha256:9255033272ab8f7bede246109ea9e7302527faf3accbf2ba7ef619e2206107ad"
     },
     "2025.10.0": {
       "linux/amd64": "docker.io/homeassistant/home-assistant:2025.10.0@sha256:ae0e2a2f03822c49a0c506bc40e367b4abc8b3207d67a6e0312b42d60867c5e5",

--- a/nix/_dockerfiles/pins/docker_io_homeassistant_home-assistant/linux_amd64/2025_10_1/Dockerfile
+++ b/nix/_dockerfiles/pins/docker_io_homeassistant_home-assistant/linux_amd64/2025_10_1/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/amd64 docker.io/homeassistant/home-assistant:2025.10.1

--- a/nix/_dockerfiles/pins/docker_io_homeassistant_home-assistant/linux_arm64/2025_10_1/Dockerfile
+++ b/nix/_dockerfiles/pins/docker_io_homeassistant_home-assistant/linux_arm64/2025_10_1/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/arm64 docker.io/homeassistant/home-assistant:2025.10.1


### PR DESCRIPTION
## Automated OCI Image Update
  
  This PR contains automated updates to OCI image references:
  
  - Version Dockerfiles generated from `images.json`
  - Pin Dockerfiles created from version tags
  - Updated `digests.json` with latest image references
  
  ### Commits
  
  ```
  c9ac16a chore: update digests.json with latest image references
682dd70 chore: generate pin Dockerfiles from version tags
  ```
  
  This PR will be automatically merged by Mergify if all checks pass.