### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -81,8 +81,8 @@
       "linux/arm64": "docker.io/n8nio/n8n:1.108.1@sha256:8509288ac9c0591ddb8a4e4a8e432e003f3cc91bf492cfed6e2c8125c3de3a94"
     },
     "nightly": {
-      "linux/amd64": "docker.io/n8nio/n8n:nightly@sha256:7f310cd5103027a03d6d7fcce21d44209d0b1b6a05c4115273a1c96de7bc50fa",
-      "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:7f310cd5103027a03d6d7fcce21d44209d0b1b6a05c4115273a1c96de7bc50fa"
+      "linux/amd64": "docker.io/n8nio/n8n:nightly@sha256:93cdf998f019b511f0d02c3099bcacca1f25fbee79a6f3b9a486ebea99239a3e",
+      "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:93cdf998f019b511f0d02c3099bcacca1f25fbee79a6f3b9a486ebea99239a3e"
     },
     "stable": {
       "linux/amd64": "docker.io/n8nio/n8n:stable@sha256:57f95a26b1b28527053fba6316d9d046395d9b4da9d0da486e838384a38fcf37",


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    369841d chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.