### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -85,8 +85,8 @@
       "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:93cdf998f019b511f0d02c3099bcacca1f25fbee79a6f3b9a486ebea99239a3e"
     },
     "stable": {
-      "linux/amd64": "docker.io/n8nio/n8n:stable@sha256:57f95a26b1b28527053fba6316d9d046395d9b4da9d0da486e838384a38fcf37",
-      "linux/arm64": "docker.io/n8nio/n8n:stable@sha256:57f95a26b1b28527053fba6316d9d046395d9b4da9d0da486e838384a38fcf37"
+      "linux/amd64": "docker.io/n8nio/n8n:stable@sha256:4da14e676858f0e7eb0fc08e49ca8902447987d00a52343917153464289400c1",
+      "linux/arm64": "docker.io/n8nio/n8n:stable@sha256:4da14e676858f0e7eb0fc08e49ca8902447987d00a52343917153464289400c1"
     }
   },
   "docker.io/nextcloud": {


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    8f3be80 chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.