### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -230,6 +230,10 @@
       "linux/amd64": "ghcr.io/open-webui/open-webui:0.6.32@sha256:412334cec4b49ed51bfa9a6d28d1fbf3d5622c3ac42f57736e7d5d2bf5f3e94a",
       "linux/arm64": "ghcr.io/open-webui/open-webui:0.6.32@sha256:412334cec4b49ed51bfa9a6d28d1fbf3d5622c3ac42f57736e7d5d2bf5f3e94a"
     },
+    "0.6.33": {
+      "linux/amd64": "ghcr.io/open-webui/open-webui:0.6.33@sha256:133c51d50defc253251150a89dfbe6d55b797a630ac44a644394d01fc80b6225",
+      "linux/arm64": "ghcr.io/open-webui/open-webui:0.6.33@sha256:133c51d50defc253251150a89dfbe6d55b797a630ac44a644394d01fc80b6225"
+    },
     "main": {
       "linux/amd64": "ghcr.io/open-webui/open-webui:main@sha256:aaedae27f1ddc19b92d89020912b5afa953ad23b721d666ad780b4f72f990a43",
       "linux/arm64": "ghcr.io/open-webui/open-webui:main@sha256:aaedae27f1ddc19b92d89020912b5afa953ad23b721d666ad780b4f72f990a43"


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    ce00e91 chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.