### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -235,8 +235,8 @@
       "linux/arm64": "ghcr.io/open-webui/open-webui:0.6.33@sha256:133c51d50defc253251150a89dfbe6d55b797a630ac44a644394d01fc80b6225"
     },
     "main": {
-      "linux/amd64": "ghcr.io/open-webui/open-webui:main@sha256:aaedae27f1ddc19b92d89020912b5afa953ad23b721d666ad780b4f72f990a43",
-      "linux/arm64": "ghcr.io/open-webui/open-webui:main@sha256:aaedae27f1ddc19b92d89020912b5afa953ad23b721d666ad780b4f72f990a43"
+      "linux/amd64": "ghcr.io/open-webui/open-webui:main@sha256:5a93a2c0943336d1bc8e3d86773172a7b007e6cb27676f9268e8b272738b70f0",
+      "linux/arm64": "ghcr.io/open-webui/open-webui:main@sha256:5a93a2c0943336d1bc8e3d86773172a7b007e6cb27676f9268e8b272738b70f0"
     },
     "main-ollama": {
       "linux/amd64": "ghcr.io/open-webui/open-webui:main-ollama@sha256:c3712bfe8e4e9a435ddf88cae142a6a7a41230592cfddb641809d3356c37099b",


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    9da8ac5 chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.