### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -419,12 +419,12 @@
       "linux/arm64": "docker.io/nextcloud:32.0@sha256:b23c43623208a7adc4f74a6123418cf328ceea175f5c034515ce0555ceda248d"
     },
     "33": {
-      "linux/amd64": "docker.io/nextcloud:33@sha256:61dd3e5816740f9f14aaba919566a6119b373e84eaa8b2b38779855b3ebc9c9f",
-      "linux/arm64": "docker.io/nextcloud:33@sha256:61dd3e5816740f9f14aaba919566a6119b373e84eaa8b2b38779855b3ebc9c9f"
+      "linux/amd64": "docker.io/nextcloud:33@sha256:03cab7c1c96745fed1d8a6c64c7d851afaca6955cf9946beaedca4575b417eff",
+      "linux/arm64": "docker.io/nextcloud:33@sha256:03cab7c1c96745fed1d8a6c64c7d851afaca6955cf9946beaedca4575b417eff"
     },
     "33.0": {
-      "linux/amd64": "docker.io/nextcloud:33.0@sha256:61dd3e5816740f9f14aaba919566a6119b373e84eaa8b2b38779855b3ebc9c9f",
-      "linux/arm64": "docker.io/nextcloud:33.0@sha256:61dd3e5816740f9f14aaba919566a6119b373e84eaa8b2b38779855b3ebc9c9f"
+      "linux/amd64": "docker.io/nextcloud:33.0@sha256:03cab7c1c96745fed1d8a6c64c7d851afaca6955cf9946beaedca4575b417eff",
+      "linux/arm64": "docker.io/nextcloud:33.0@sha256:03cab7c1c96745fed1d8a6c64c7d851afaca6955cf9946beaedca4575b417eff"
     }
   },
   "docker.io/plexinc/pms-docker": {


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    76b61a06 chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.