### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -419,12 +419,12 @@
       "linux/arm64": "docker.io/nextcloud:32.0@sha256:b23c43623208a7adc4f74a6123418cf328ceea175f5c034515ce0555ceda248d"
     },
     "33": {
-      "linux/amd64": "docker.io/nextcloud:33@sha256:03cab7c1c96745fed1d8a6c64c7d851afaca6955cf9946beaedca4575b417eff",
-      "linux/arm64": "docker.io/nextcloud:33@sha256:03cab7c1c96745fed1d8a6c64c7d851afaca6955cf9946beaedca4575b417eff"
+      "linux/amd64": "docker.io/nextcloud:33@sha256:8eeeb6ac8438fe0dda20d961d5eb0adafcddbc16db361c1ca81ab122a65acdfa",
+      "linux/arm64": "docker.io/nextcloud:33@sha256:8eeeb6ac8438fe0dda20d961d5eb0adafcddbc16db361c1ca81ab122a65acdfa"
     },
     "33.0": {
-      "linux/amd64": "docker.io/nextcloud:33.0@sha256:03cab7c1c96745fed1d8a6c64c7d851afaca6955cf9946beaedca4575b417eff",
-      "linux/arm64": "docker.io/nextcloud:33.0@sha256:03cab7c1c96745fed1d8a6c64c7d851afaca6955cf9946beaedca4575b417eff"
+      "linux/amd64": "docker.io/nextcloud:33.0@sha256:8eeeb6ac8438fe0dda20d961d5eb0adafcddbc16db361c1ca81ab122a65acdfa",
+      "linux/arm64": "docker.io/nextcloud:33.0@sha256:8eeeb6ac8438fe0dda20d961d5eb0adafcddbc16db361c1ca81ab122a65acdfa"
     }
   },
   "docker.io/plexinc/pms-docker": {


### PR DESCRIPTION
## Automated OCI Image Update
  
  This PR contains automated updates to OCI image references:
  
  - Version Dockerfiles generated from `images.json`
  - Pin Dockerfiles created from version tags
  - Updated `digests.json` with latest image references
  
  ### Commits
  
  ```
  01b97aae chore: update digests.json with latest image references
  ```
  
  This PR will be automatically merged by Mergify if all checks pass.