### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -411,12 +411,12 @@
       "linux/arm64": "docker.io/nextcloud:31.0@sha256:07ec73cc816e58d6f45a162cd53ef886462c29271a23fc68d0124cec276e3767"
     },
     "32": {
-      "linux/amd64": "docker.io/nextcloud:32@sha256:b23c43623208a7adc4f74a6123418cf328ceea175f5c034515ce0555ceda248d",
-      "linux/arm64": "docker.io/nextcloud:32@sha256:b23c43623208a7adc4f74a6123418cf328ceea175f5c034515ce0555ceda248d"
+      "linux/amd64": "docker.io/nextcloud:32@sha256:17b6b3012de55ec660ec1dbebf1500d7a67107ff718e6a23650594712d902f63",
+      "linux/arm64": "docker.io/nextcloud:32@sha256:17b6b3012de55ec660ec1dbebf1500d7a67107ff718e6a23650594712d902f63"
     },
     "32.0": {
-      "linux/amd64": "docker.io/nextcloud:32.0@sha256:b23c43623208a7adc4f74a6123418cf328ceea175f5c034515ce0555ceda248d",
-      "linux/arm64": "docker.io/nextcloud:32.0@sha256:b23c43623208a7adc4f74a6123418cf328ceea175f5c034515ce0555ceda248d"
+      "linux/amd64": "docker.io/nextcloud:32.0@sha256:17b6b3012de55ec660ec1dbebf1500d7a67107ff718e6a23650594712d902f63",
+      "linux/arm64": "docker.io/nextcloud:32.0@sha256:17b6b3012de55ec660ec1dbebf1500d7a67107ff718e6a23650594712d902f63"
     },
     "33": {
       "linux/amd64": "docker.io/nextcloud:33@sha256:8eeeb6ac8438fe0dda20d961d5eb0adafcddbc16db361c1ca81ab122a65acdfa",


### PR DESCRIPTION
## Automated OCI Image Update
  
  This PR contains automated updates to OCI image references:
  
  - Version Dockerfiles generated from `images.json`
  - Pin Dockerfiles created from version tags
  - Updated `digests.json` with latest image references
  
  ### Commits
  
  ```
  3bd41186 chore: update digests.json with latest image references
  ```
  
  This PR will be automatically merged by Mergify if all checks pass.