### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -423,8 +423,8 @@
       "linux/arm64": "docker.io/nextcloud:33@sha256:3e676af625884f4e228ac6655f51a4ea65f3a1e68f320ad23d17fccfa00d5b54"
     },
     "33.0": {
-      "linux/amd64": "docker.io/nextcloud:33.0@sha256:8eeeb6ac8438fe0dda20d961d5eb0adafcddbc16db361c1ca81ab122a65acdfa",
-      "linux/arm64": "docker.io/nextcloud:33.0@sha256:8eeeb6ac8438fe0dda20d961d5eb0adafcddbc16db361c1ca81ab122a65acdfa"
+      "linux/amd64": "docker.io/nextcloud:33.0@sha256:3e676af625884f4e228ac6655f51a4ea65f3a1e68f320ad23d17fccfa00d5b54",
+      "linux/arm64": "docker.io/nextcloud:33.0@sha256:3e676af625884f4e228ac6655f51a4ea65f3a1e68f320ad23d17fccfa00d5b54"
     }
   },
   "docker.io/plexinc/pms-docker": {

--- a/nix/_dockerfiles/pins/docker_io_vaultwarden_server/linux_amd64/1_35_6/Dockerfile
+++ b/nix/_dockerfiles/pins/docker_io_vaultwarden_server/linux_amd64/1_35_6/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/amd64 docker.io/vaultwarden/server:1.35.6

--- a/nix/_dockerfiles/pins/docker_io_vaultwarden_server/linux_arm64/1_35_6/Dockerfile
+++ b/nix/_dockerfiles/pins/docker_io_vaultwarden_server/linux_arm64/1_35_6/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/arm64 docker.io/vaultwarden/server:1.35.6


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    811c981f chore: update digests.json with latest image references
752f4e46 chore: generate pin Dockerfiles from version tags
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.