### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -663,12 +663,12 @@
       "linux/arm64": "ghcr.io/open-webui/open-webui:0.8@sha256:8113fa5510020ef05a44afc0c42d33eabeeb2524a996e3e3fb8c437c00f0d792"
     },
     "main": {
-      "linux/amd64": "ghcr.io/open-webui/open-webui:main@sha256:b8095f79a6a8ffad8f830bdacc9b5b0aef805689b31bca0b065cc2424d3cfaeb",
-      "linux/arm64": "ghcr.io/open-webui/open-webui:main@sha256:b8095f79a6a8ffad8f830bdacc9b5b0aef805689b31bca0b065cc2424d3cfaeb"
+      "linux/amd64": "ghcr.io/open-webui/open-webui:main@sha256:e01a51e3278dcf9ce38f937f08e33bee31e64f78eb0ed026403f8893893d2edf",
+      "linux/arm64": "ghcr.io/open-webui/open-webui:main@sha256:e01a51e3278dcf9ce38f937f08e33bee31e64f78eb0ed026403f8893893d2edf"
     },
     "main-ollama": {
-      "linux/amd64": "ghcr.io/open-webui/open-webui:main-ollama@sha256:9082d4aa9a47593609006077499c7cbac5c67d3a17094d96bdf844a99b0b923f",
-      "linux/arm64": "ghcr.io/open-webui/open-webui:main-ollama@sha256:9082d4aa9a47593609006077499c7cbac5c67d3a17094d96bdf844a99b0b923f"
+      "linux/amd64": "ghcr.io/open-webui/open-webui:main-ollama@sha256:9847a232c9f372ab2c26cec3e57979f2f5b4274c739f11ee19ab156c0af7f07a",
+      "linux/arm64": "ghcr.io/open-webui/open-webui:main-ollama@sha256:9847a232c9f372ab2c26cec3e57979f2f5b4274c739f11ee19ab156c0af7f07a"
     },
     "v0.6.25": {
       "linux/amd64": "ghcr.io/open-webui/open-webui:v0.6.25@sha256:1c2c3e7e84d5bb0b5471e4de881539cf39e724835a5c53b252518e82ea0c568e",

--- a/nix/_dockerfiles/pins/ghcr_io_open-webui_open-webui/linux_amd64/0_9/Dockerfile
+++ b/nix/_dockerfiles/pins/ghcr_io_open-webui_open-webui/linux_amd64/0_9/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/amd64 ghcr.io/open-webui/open-webui:0.9

--- a/nix/_dockerfiles/pins/ghcr_io_open-webui_open-webui/linux_amd64/v0_9_0/Dockerfile
+++ b/nix/_dockerfiles/pins/ghcr_io_open-webui_open-webui/linux_amd64/v0_9_0/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/amd64 ghcr.io/open-webui/open-webui:v0.9.0

--- a/nix/_dockerfiles/pins/ghcr_io_open-webui_open-webui/linux_arm64/0_9/Dockerfile
+++ b/nix/_dockerfiles/pins/ghcr_io_open-webui_open-webui/linux_arm64/0_9/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/arm64 ghcr.io/open-webui/open-webui:0.9

--- a/nix/_dockerfiles/pins/ghcr_io_open-webui_open-webui/linux_arm64/v0_9_0/Dockerfile
+++ b/nix/_dockerfiles/pins/ghcr_io_open-webui_open-webui/linux_arm64/v0_9_0/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/arm64 ghcr.io/open-webui/open-webui:v0.9.0


### PR DESCRIPTION
## Automated OCI Image Update
  
  This PR contains automated updates to OCI image references:
  
  - Version Dockerfiles generated from `images.json`
  - Pin Dockerfiles created from version tags
  - Updated `digests.json` with latest image references
  
  ### Commits
  
  ```
  daf519ac chore: update digests.json with latest image references
cd3d0b55 chore: generate pin Dockerfiles from version tags
  ```
  
  This PR will be automatically merged by Mergify if all checks pass.