### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -663,12 +663,12 @@
       "linux/arm64": "ghcr.io/open-webui/open-webui:0.8@sha256:8113fa5510020ef05a44afc0c42d33eabeeb2524a996e3e3fb8c437c00f0d792"
     },
     "main": {
-      "linux/amd64": "ghcr.io/open-webui/open-webui:main@sha256:e01a51e3278dcf9ce38f937f08e33bee31e64f78eb0ed026403f8893893d2edf",
-      "linux/arm64": "ghcr.io/open-webui/open-webui:main@sha256:e01a51e3278dcf9ce38f937f08e33bee31e64f78eb0ed026403f8893893d2edf"
+      "linux/amd64": "ghcr.io/open-webui/open-webui:main@sha256:1e834205e71a97812c8e3e8cbf05e7ab40887143a65aa78b85fe7930d5892f0d",
+      "linux/arm64": "ghcr.io/open-webui/open-webui:main@sha256:1e834205e71a97812c8e3e8cbf05e7ab40887143a65aa78b85fe7930d5892f0d"
     },
     "main-ollama": {
-      "linux/amd64": "ghcr.io/open-webui/open-webui:main-ollama@sha256:9847a232c9f372ab2c26cec3e57979f2f5b4274c739f11ee19ab156c0af7f07a",
-      "linux/arm64": "ghcr.io/open-webui/open-webui:main-ollama@sha256:9847a232c9f372ab2c26cec3e57979f2f5b4274c739f11ee19ab156c0af7f07a"
+      "linux/amd64": "ghcr.io/open-webui/open-webui:main-ollama@sha256:bd286ef2302ba9d88ae3e3662834dacd86c368f5c49a8e9756e433d32e00e368",
+      "linux/arm64": "ghcr.io/open-webui/open-webui:main-ollama@sha256:bd286ef2302ba9d88ae3e3662834dacd86c368f5c49a8e9756e433d32e00e368"
     },
     "v0.6.25": {
       "linux/amd64": "ghcr.io/open-webui/open-webui:v0.6.25@sha256:1c2c3e7e84d5bb0b5471e4de881539cf39e724835a5c53b252518e82ea0c568e",


### PR DESCRIPTION
## Automated OCI Image Update
  
  This PR contains automated updates to OCI image references:
  
  - Version Dockerfiles generated from `images.json`
  - Pin Dockerfiles created from version tags
  - Updated `digests.json` with latest image references
  
  ### Commits
  
  ```
  471a6849 chore: update digests.json with latest image references
  ```
  
  This PR will be automatically merged by Mergify if all checks pass.