### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -663,12 +663,12 @@
       "linux/arm64": "ghcr.io/open-webui/open-webui:0.8@sha256:8113fa5510020ef05a44afc0c42d33eabeeb2524a996e3e3fb8c437c00f0d792"
     },
     "main": {
-      "linux/amd64": "ghcr.io/open-webui/open-webui:main@sha256:1e834205e71a97812c8e3e8cbf05e7ab40887143a65aa78b85fe7930d5892f0d",
-      "linux/arm64": "ghcr.io/open-webui/open-webui:main@sha256:1e834205e71a97812c8e3e8cbf05e7ab40887143a65aa78b85fe7930d5892f0d"
+      "linux/amd64": "ghcr.io/open-webui/open-webui:main@sha256:c2e4723fdbca5de8f9f0529e22b78acf5bc312a88da730bed88860063d028fe8",
+      "linux/arm64": "ghcr.io/open-webui/open-webui:main@sha256:c2e4723fdbca5de8f9f0529e22b78acf5bc312a88da730bed88860063d028fe8"
     },
     "main-ollama": {
-      "linux/amd64": "ghcr.io/open-webui/open-webui:main-ollama@sha256:bd286ef2302ba9d88ae3e3662834dacd86c368f5c49a8e9756e433d32e00e368",
-      "linux/arm64": "ghcr.io/open-webui/open-webui:main-ollama@sha256:bd286ef2302ba9d88ae3e3662834dacd86c368f5c49a8e9756e433d32e00e368"
+      "linux/amd64": "ghcr.io/open-webui/open-webui:main-ollama@sha256:e54049418c30b23c86ce82eb91ed6be9e0215bda39520d9e90cab4ead9f90843",
+      "linux/arm64": "ghcr.io/open-webui/open-webui:main-ollama@sha256:e54049418c30b23c86ce82eb91ed6be9e0215bda39520d9e90cab4ead9f90843"
     },
     "v0.6.25": {
       "linux/amd64": "ghcr.io/open-webui/open-webui:v0.6.25@sha256:1c2c3e7e84d5bb0b5471e4de881539cf39e724835a5c53b252518e82ea0c568e",

--- a/nix/_dockerfiles/pins/ghcr_io_open-webui_open-webui/linux_amd64/v0_9_2/Dockerfile
+++ b/nix/_dockerfiles/pins/ghcr_io_open-webui_open-webui/linux_amd64/v0_9_2/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/amd64 ghcr.io/open-webui/open-webui:v0.9.2

--- a/nix/_dockerfiles/pins/ghcr_io_open-webui_open-webui/linux_arm64/v0_9_2/Dockerfile
+++ b/nix/_dockerfiles/pins/ghcr_io_open-webui_open-webui/linux_arm64/v0_9_2/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/arm64 ghcr.io/open-webui/open-webui:v0.9.2


### PR DESCRIPTION
## Automated OCI Image Update
  
  This PR contains automated updates to OCI image references:
  
  - Version Dockerfiles generated from `images.json`
  - Pin Dockerfiles created from version tags
  - Updated `digests.json` with latest image references
  
  ### Commits
  
  ```
  4e759312 chore: update digests.json with latest image references
14d2dbe6 chore: generate pin Dockerfiles from version tags
  ```
  
  This PR will be automatically merged by Mergify if all checks pass.