### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -389,8 +389,8 @@
       "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:c987f5c81c6f543db8e257d5fbf3901c0592b427cf09b653d7f3d8fc1ed4bc4a"
     },
     "stable": {
-      "linux/amd64": "docker.io/n8nio/n8n:stable@sha256:4f448824ec99e1160e49eeb1c5bf2130a5d244fe9029e871a9f4d9f126dbfc98",
-      "linux/arm64": "docker.io/n8nio/n8n:stable@sha256:4f448824ec99e1160e49eeb1c5bf2130a5d244fe9029e871a9f4d9f126dbfc98"
+      "linux/amd64": "docker.io/n8nio/n8n:stable@sha256:a293b89bac876872a0c1ef0fbbb7ce056aa2d215f62917acf032ecb8010199af",
+      "linux/arm64": "docker.io/n8nio/n8n:stable@sha256:a293b89bac876872a0c1ef0fbbb7ce056aa2d215f62917acf032ecb8010199af"
     }
   },
   "docker.io/nextcloud": {


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    fb1a19ff chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.