### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -141,8 +141,8 @@
       "linux/arm64": "docker.io/homeassistant/home-assistant:2026.2.3@sha256:96fa92d83fa8dae987fbbbcf58b1fea1140985ff6a8517b37f7b65c76ef20133"
     },
     "2026.3": {
-      "linux/amd64": "docker.io/homeassistant/home-assistant:2026.3@sha256:572a5d030f652e9ef6c6d4f6631169af83eb3b739c9b4b3965669f5e9d9f3858",
-      "linux/arm64": "docker.io/homeassistant/home-assistant:2026.3@sha256:572a5d030f652e9ef6c6d4f6631169af83eb3b739c9b4b3965669f5e9d9f3858"
+      "linux/amd64": "docker.io/homeassistant/home-assistant:2026.3@sha256:916682086154a7390114a9788782b8efb199852d4f7d47066722c2bc5d1829e6",
+      "linux/arm64": "docker.io/homeassistant/home-assistant:2026.3@sha256:916682086154a7390114a9788782b8efb199852d4f7d47066722c2bc5d1829e6"
     },
     "2026.3.0": {
       "linux/amd64": "docker.io/homeassistant/home-assistant:2026.3.0@sha256:4fb4ad85fad2250ccff6ec0670827bdcdc46b8bab2b9cbfb8ecdc28da7210630",

--- a/nix/_dockerfiles/pins/docker_io_jellyfin_jellyfin/linux_amd64/10_11_8/Dockerfile
+++ b/nix/_dockerfiles/pins/docker_io_jellyfin_jellyfin/linux_amd64/10_11_8/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/amd64 docker.io/jellyfin/jellyfin:10.11.8

--- a/nix/_dockerfiles/pins/docker_io_jellyfin_jellyfin/linux_arm64/10_11_8/Dockerfile
+++ b/nix/_dockerfiles/pins/docker_io_jellyfin_jellyfin/linux_arm64/10_11_8/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/arm64 docker.io/jellyfin/jellyfin:10.11.8


### PR DESCRIPTION
## Automated OCI Image Update
  
  This PR contains automated updates to OCI image references:
  
  - Version Dockerfiles generated from `images.json`
  - Pin Dockerfiles created from version tags
  - Updated `digests.json` with latest image references
  
  ### Commits
  
  ```
  de784cda chore: update digests.json with latest image references
06f8cd58 chore: generate pin Dockerfiles from version tags
  ```
  
  This PR will be automatically merged by Mergify if all checks pass.