### PR TITLE
chore: update OCI image references

### DIFF
--- a/nix/_dockerfiles/pins/docker_io_n8nio_n8n/linux_amd64/2_18_3/Dockerfile
+++ b/nix/_dockerfiles/pins/docker_io_n8nio_n8n/linux_amd64/2_18_3/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/amd64 docker.io/n8nio/n8n:2.18.3

--- a/nix/_dockerfiles/pins/docker_io_n8nio_n8n/linux_arm64/2_18_3/Dockerfile
+++ b/nix/_dockerfiles/pins/docker_io_n8nio_n8n/linux_arm64/2_18_3/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/arm64 docker.io/n8nio/n8n:2.18.3

--- a/nix/_dockerfiles/pins/ghcr_io_immich-app_immich-server/linux_amd64/v2_7_5/Dockerfile
+++ b/nix/_dockerfiles/pins/ghcr_io_immich-app_immich-server/linux_amd64/v2_7_5/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/amd64 ghcr.io/immich-app/immich-server:v2.7.5

--- a/nix/_dockerfiles/pins/ghcr_io_immich-app_immich-server/linux_arm64/v2_7_5/Dockerfile
+++ b/nix/_dockerfiles/pins/ghcr_io_immich-app_immich-server/linux_arm64/v2_7_5/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/arm64 ghcr.io/immich-app/immich-server:v2.7.5


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    c7870fe1 chore: generate pin Dockerfiles from version tags
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.