### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -529,6 +529,10 @@
     "1.35.7": {
       "linux/amd64": "docker.io/vaultwarden/server:1.35.7@sha256:9a8eec71f4a52411cc43edc7a50f33e9b6f62b5baca0dd95f0c6e7fd60f1a341",
       "linux/arm64": "docker.io/vaultwarden/server:1.35.7@sha256:9a8eec71f4a52411cc43edc7a50f33e9b6f62b5baca0dd95f0c6e7fd60f1a341"
+    },
+    "1.35.8": {
+      "linux/amd64": "docker.io/vaultwarden/server:1.35.8@sha256:c4f6056fe0c288a052a223cecd263a90d1dda1a0177bb5b054a363a6c7b211d9",
+      "linux/arm64": "docker.io/vaultwarden/server:1.35.8@sha256:c4f6056fe0c288a052a223cecd263a90d1dda1a0177bb5b054a363a6c7b211d9"
     }
   },
   "ghcr.io/immich-app/immich-server": {


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    3a1f0d66 chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.