### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -441,8 +441,8 @@
       "linux/arm64": "docker.io/n8nio/n8n:2.9.2@sha256:52bc65540cbfb6f8b5320bafaf28bcc018ae08124bb0a7cbf5ca7f044b54d698"
     },
     "nightly": {
-      "linux/amd64": "docker.io/n8nio/n8n:nightly@sha256:06ac8684b6a52a8fe1caa43b118c614e752113885912452c8e68ca34bcb436ba",
-      "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:06ac8684b6a52a8fe1caa43b118c614e752113885912452c8e68ca34bcb436ba"
+      "linux/amd64": "docker.io/n8nio/n8n:nightly@sha256:6d2ceda4d5f3fe129208d21a6ed09dc1366e042842de32be3f83f3a52d0ceffd",
+      "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:6d2ceda4d5f3fe129208d21a6ed09dc1366e042842de32be3f83f3a52d0ceffd"
     },
     "stable": {
       "linux/amd64": "docker.io/n8nio/n8n:stable@sha256:a293b89bac876872a0c1ef0fbbb7ce056aa2d215f62917acf032ecb8010199af",


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    70d41314 chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.