### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -449,8 +449,8 @@
       "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:4d2f742f6abf29daff9969f973613cef30e69712650cb7057a71210404c7fffa"
     },
     "stable": {
-      "linux/amd64": "docker.io/n8nio/n8n:stable@sha256:a50abe80b18ed7f5a8b253d3870d640c0b6af2d4b55c325b316ed3174a0b705f",
-      "linux/arm64": "docker.io/n8nio/n8n:stable@sha256:a50abe80b18ed7f5a8b253d3870d640c0b6af2d4b55c325b316ed3174a0b705f"
+      "linux/amd64": "docker.io/n8nio/n8n:stable@sha256:13e82df0fafc19ad47077e196d6939caaf7364d6d8360605bc328e0c1059b992",
+      "linux/arm64": "docker.io/n8nio/n8n:stable@sha256:13e82df0fafc19ad47077e196d6939caaf7364d6d8360605bc328e0c1059b992"
     }
   },
   "docker.io/nextcloud": {

--- a/nix/_dockerfiles/pins/docker_io_n8nio_n8n/linux_amd64/2_19_0/Dockerfile
+++ b/nix/_dockerfiles/pins/docker_io_n8nio_n8n/linux_amd64/2_19_0/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/amd64 docker.io/n8nio/n8n:2.19.0

--- a/nix/_dockerfiles/pins/docker_io_n8nio_n8n/linux_arm64/2_19_0/Dockerfile
+++ b/nix/_dockerfiles/pins/docker_io_n8nio_n8n/linux_arm64/2_19_0/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/arm64 docker.io/n8nio/n8n:2.19.0


### PR DESCRIPTION
## Automated OCI Image Update
  
  This PR contains automated updates to OCI image references:
  
  - Version Dockerfiles generated from `images.json`
  - Pin Dockerfiles created from version tags
  - Updated `digests.json` with latest image references
  
  ### Commits
  
  ```
  2b4e5c04 chore: update digests.json with latest image references
69cd0a5d chore: generate pin Dockerfiles from version tags
  ```
  
  This PR will be automatically merged by Mergify if all checks pass.