### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -453,8 +453,8 @@
       "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:67641292309c1b1d246be1750aeb4f15d8ecc2e1eee2a29f2d485a0b10acc85d"
     },
     "stable": {
-      "linux/amd64": "docker.io/n8nio/n8n:stable@sha256:13e82df0fafc19ad47077e196d6939caaf7364d6d8360605bc328e0c1059b992",
-      "linux/arm64": "docker.io/n8nio/n8n:stable@sha256:13e82df0fafc19ad47077e196d6939caaf7364d6d8360605bc328e0c1059b992"
+      "linux/amd64": "docker.io/n8nio/n8n:stable@sha256:2d70fafea7c0c397f40df30daa31243c0bff590e9e87e0430398e7cb4d3d8d0b",
+      "linux/arm64": "docker.io/n8nio/n8n:stable@sha256:2d70fafea7c0c397f40df30daa31243c0bff590e9e87e0430398e7cb4d3d8d0b"
     }
   },
   "docker.io/nextcloud": {


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    e7167916 chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.