### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -348,6 +348,10 @@
       "linux/amd64": "docker.io/n8nio/n8n:2.19.0@sha256:db0b9941d16b31d1e79b73b6c170de2342696de9136ed1c0f1bab970d9cfc817",
       "linux/arm64": "docker.io/n8nio/n8n:2.19.0@sha256:db0b9941d16b31d1e79b73b6c170de2342696de9136ed1c0f1bab970d9cfc817"
     },
+    "2.19.1": {
+      "linux/amd64": "docker.io/n8nio/n8n:2.19.1@sha256:2ef1d15faab79076174bb51f04394684fa823552405a8bb412d3a632748404c5",
+      "linux/arm64": "docker.io/n8nio/n8n:2.19.1@sha256:2ef1d15faab79076174bb51f04394684fa823552405a8bb412d3a632748404c5"
+    },
     "2.2.0": {
       "linux/amd64": "docker.io/n8nio/n8n:2.2.0@sha256:d668889ca1f17367027f52bcee525dfde6d369d6b64be4a66b6fa22cb97f9ff3",
       "linux/arm64": "docker.io/n8nio/n8n:2.2.0@sha256:d668889ca1f17367027f52bcee525dfde6d369d6b64be4a66b6fa22cb97f9ff3"


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    0f839f0b chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.