### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -461,8 +461,8 @@
       "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:1b74082e28ad4ea0951678de46bdb492351d11e90957184c0b55cd67715b4c0c"
     },
     "stable": {
-      "linux/amd64": "docker.io/n8nio/n8n:stable@sha256:6f64b98eb9118c27403a3dc9b36a187690dd47a5245bcb70a8ce137b0a008ac1",
-      "linux/arm64": "docker.io/n8nio/n8n:stable@sha256:6f64b98eb9118c27403a3dc9b36a187690dd47a5245bcb70a8ce137b0a008ac1"
+      "linux/amd64": "docker.io/n8nio/n8n:stable@sha256:4613a202077b00e9a66a9ed83cccae01866ddc0df59222d91409bfb0d70007dd",
+      "linux/arm64": "docker.io/n8nio/n8n:stable@sha256:4613a202077b00e9a66a9ed83cccae01866ddc0df59222d91409bfb0d70007dd"
     }
   },
   "docker.io/nextcloud": {


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    4e92845c chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.