### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -461,8 +461,8 @@
       "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:d8c76ba50fd455f45c809d542fcd791fa5e4ca0c420df8a7f590bae45cfd972e"
     },
     "stable": {
-      "linux/amd64": "docker.io/n8nio/n8n:stable@sha256:4613a202077b00e9a66a9ed83cccae01866ddc0df59222d91409bfb0d70007dd",
-      "linux/arm64": "docker.io/n8nio/n8n:stable@sha256:4613a202077b00e9a66a9ed83cccae01866ddc0df59222d91409bfb0d70007dd"
+      "linux/amd64": "docker.io/n8nio/n8n:stable@sha256:385ea908fee7f77792ccf1a1cfd8f1509f2b55d9b20db7b3b00df5e8f85d8875",
+      "linux/arm64": "docker.io/n8nio/n8n:stable@sha256:385ea908fee7f77792ccf1a1cfd8f1509f2b55d9b20db7b3b00df5e8f85d8875"
     }
   },
   "docker.io/nextcloud": {

--- a/nix/_dockerfiles/pins/docker_io_n8nio_n8n/linux_amd64/2_20_0/Dockerfile
+++ b/nix/_dockerfiles/pins/docker_io_n8nio_n8n/linux_amd64/2_20_0/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/amd64 docker.io/n8nio/n8n:2.20.0

--- a/nix/_dockerfiles/pins/docker_io_n8nio_n8n/linux_arm64/2_20_0/Dockerfile
+++ b/nix/_dockerfiles/pins/docker_io_n8nio_n8n/linux_arm64/2_20_0/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/arm64 docker.io/n8nio/n8n:2.20.0


### PR DESCRIPTION
## Automated OCI Image Update
  
  This PR contains automated updates to OCI image references:
  
  - Version Dockerfiles generated from `images.json`
  - Pin Dockerfiles created from version tags
  - Updated `digests.json` with latest image references
  
  ### Commits
  
  ```
  a2d100aa chore: update digests.json with latest image references
9d33a2e2 chore: generate pin Dockerfiles from version tags
  ```
  
  This PR will be automatically merged by Mergify if all checks pass.