### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -465,8 +465,8 @@
       "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:d8c76ba50fd455f45c809d542fcd791fa5e4ca0c420df8a7f590bae45cfd972e"
     },
     "stable": {
-      "linux/amd64": "docker.io/n8nio/n8n:stable@sha256:385ea908fee7f77792ccf1a1cfd8f1509f2b55d9b20db7b3b00df5e8f85d8875",
-      "linux/arm64": "docker.io/n8nio/n8n:stable@sha256:385ea908fee7f77792ccf1a1cfd8f1509f2b55d9b20db7b3b00df5e8f85d8875"
+      "linux/amd64": "docker.io/n8nio/n8n:stable@sha256:2fd759104a01b6f269c52fe0a355b08ef030af20e23882b95fec28b6668d9c32",
+      "linux/arm64": "docker.io/n8nio/n8n:stable@sha256:2fd759104a01b6f269c52fe0a355b08ef030af20e23882b95fec28b6668d9c32"
     }
   },
   "docker.io/nextcloud": {

--- a/nix/_dockerfiles/pins/docker_io_n8nio_n8n/linux_amd64/2_20_1/Dockerfile
+++ b/nix/_dockerfiles/pins/docker_io_n8nio_n8n/linux_amd64/2_20_1/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/amd64 docker.io/n8nio/n8n:2.20.1

--- a/nix/_dockerfiles/pins/docker_io_n8nio_n8n/linux_arm64/2_20_1/Dockerfile
+++ b/nix/_dockerfiles/pins/docker_io_n8nio_n8n/linux_arm64/2_20_1/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/arm64 docker.io/n8nio/n8n:2.20.1


### PR DESCRIPTION
## Automated OCI Image Update
  
  This PR contains automated updates to OCI image references:
  
  - Version Dockerfiles generated from `images.json`
  - Pin Dockerfiles created from version tags
  - Updated `digests.json` with latest image references
  
  ### Commits
  
  ```
  5c74f12a chore: update digests.json with latest image references
385b3888 chore: generate pin Dockerfiles from version tags
  ```
  
  This PR will be automatically merged by Mergify if all checks pass.