### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -388,6 +388,10 @@
       "linux/amd64": "docker.io/n8nio/n8n:2.20.4@sha256:8620db7c2bd1353c3f0a656a3197605b475afd0a0bb171703dc6d4539a92c0cd",
       "linux/arm64": "docker.io/n8nio/n8n:2.20.4@sha256:8620db7c2bd1353c3f0a656a3197605b475afd0a0bb171703dc6d4539a92c0cd"
     },
+    "2.20.5": {
+      "linux/amd64": "docker.io/n8nio/n8n:2.20.5@sha256:92e5cd1bfe6453a382ddf822db1f95ad63764a8f87ae33464a5d6721e3faa738",
+      "linux/arm64": "docker.io/n8nio/n8n:2.20.5@sha256:92e5cd1bfe6453a382ddf822db1f95ad63764a8f87ae33464a5d6721e3faa738"
+    },
     "2.3.0": {
       "linux/amd64": "docker.io/n8nio/n8n:2.3.0@sha256:86818ab591423129251677c49e290ea0b9d2c757dc150a16d15ec207e09b102d",
       "linux/arm64": "docker.io/n8nio/n8n:2.3.0@sha256:86818ab591423129251677c49e290ea0b9d2c757dc150a16d15ec207e09b102d"


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    d679a288 chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.