### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -481,8 +481,8 @@
       "linux/arm64": "docker.io/n8nio/n8n:2.9.2@sha256:52bc65540cbfb6f8b5320bafaf28bcc018ae08124bb0a7cbf5ca7f044b54d698"
     },
     "nightly": {
-      "linux/amd64": "docker.io/n8nio/n8n:nightly@sha256:b58df36b3aa0b16eb8dfe1ec8d7c40595a83d63e289c148939cf72c5e56cc741",
-      "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:b58df36b3aa0b16eb8dfe1ec8d7c40595a83d63e289c148939cf72c5e56cc741"
+      "linux/amd64": "docker.io/n8nio/n8n:nightly@sha256:5c646149bdee4932a6d5527e45e626e30a72655edd83d146a2d8fa20b4ffea8f",
+      "linux/arm64": "docker.io/n8nio/n8n:nightly@sha256:5c646149bdee4932a6d5527e45e626e30a72655edd83d146a2d8fa20b4ffea8f"
     },
     "stable": {
       "linux/amd64": "docker.io/n8nio/n8n:stable@sha256:b1b0c592735e24acd3cc64db83f94ef4efd8e331e47c6883249cc51cc1bea16b",


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    3f80af1b chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.