### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -195,6 +195,10 @@
     "2026.5.0": {
       "linux/amd64": "docker.io/homeassistant/home-assistant:2026.5.0@sha256:8edcb16cff8158e87a3a2b48b3bcca05c30dcea0212eb6a2fe940b6d52ed216a",
       "linux/arm64": "docker.io/homeassistant/home-assistant:2026.5.0@sha256:8edcb16cff8158e87a3a2b48b3bcca05c30dcea0212eb6a2fe940b6d52ed216a"
+    },
+    "2026.5.1": {
+      "linux/amd64": "docker.io/homeassistant/home-assistant:2026.5.1@sha256:d4fbec16196d5c8bedf32647f0ca7165f654d92a2e81f35a373508d3226cb867",
+      "linux/arm64": "docker.io/homeassistant/home-assistant:2026.5.1@sha256:d4fbec16196d5c8bedf32647f0ca7165f654d92a2e81f35a373508d3226cb867"
     }
   },
   "docker.io/jellyfin/jellyfin": {


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    e77d5bba chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.