### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -799,8 +799,8 @@
       "linux/arm64": "ghcr.io/open-webui/open-webui:0.9@sha256:172e1fe0e89af2a07f42f2b1d943f30c8ddd7b9c2e182f3678b4790cdb83abea"
     },
     "main": {
-      "linux/amd64": "ghcr.io/open-webui/open-webui:main@sha256:c2e4723fdbca5de8f9f0529e22b78acf5bc312a88da730bed88860063d028fe8",
-      "linux/arm64": "ghcr.io/open-webui/open-webui:main@sha256:c2e4723fdbca5de8f9f0529e22b78acf5bc312a88da730bed88860063d028fe8"
+      "linux/amd64": "ghcr.io/open-webui/open-webui:main@sha256:a6da0c292081d810a396ce786a10536d0b1b9ba2925dcca20ebb03f9fa90dbff",
+      "linux/arm64": "ghcr.io/open-webui/open-webui:main@sha256:a6da0c292081d810a396ce786a10536d0b1b9ba2925dcca20ebb03f9fa90dbff"
     },
     "main-ollama": {
       "linux/amd64": "ghcr.io/open-webui/open-webui:main-ollama@sha256:91b21c6470d266837dc7f670ad2425f40352f6cb62e8b2bb27d833378389af14",

--- a/nix/_dockerfiles/pins/ghcr_io_open-webui_open-webui/linux_amd64/v0_9_4/Dockerfile
+++ b/nix/_dockerfiles/pins/ghcr_io_open-webui_open-webui/linux_amd64/v0_9_4/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/amd64 ghcr.io/open-webui/open-webui:v0.9.4

--- a/nix/_dockerfiles/pins/ghcr_io_open-webui_open-webui/linux_arm64/v0_9_4/Dockerfile
+++ b/nix/_dockerfiles/pins/ghcr_io_open-webui_open-webui/linux_arm64/v0_9_4/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/arm64 ghcr.io/open-webui/open-webui:v0.9.4


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    995bf899 chore: update digests.json with latest image references
fb7eaec2 chore: generate pin Dockerfiles from version tags
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.