### PR TITLE
chore: update OCI image references

### DIFF
--- a/digests.json
+++ b/digests.json
@@ -893,6 +893,10 @@
     "v0.9.2": {
       "linux/amd64": "ghcr.io/open-webui/open-webui:v0.9.2@sha256:a7e4796ae894d1e2a0c1824860ade472f35c507608a01c3581377b5c19b0ed49",
       "linux/arm64": "ghcr.io/open-webui/open-webui:v0.9.2@sha256:a7e4796ae894d1e2a0c1824860ade472f35c507608a01c3581377b5c19b0ed49"
+    },
+    "v0.9.4": {
+      "linux/amd64": "ghcr.io/open-webui/open-webui:v0.9.4@sha256:172e1fe0e89af2a07f42f2b1d943f30c8ddd7b9c2e182f3678b4790cdb83abea",
+      "linux/arm64": "ghcr.io/open-webui/open-webui:v0.9.4@sha256:172e1fe0e89af2a07f42f2b1d943f30c8ddd7b9c2e182f3678b4790cdb83abea"
     }
   },
   "ghcr.io/paperless-ngx/paperless-ngx": {


### PR DESCRIPTION
## Automated OCI Image Update
    
    This PR contains automated updates to OCI image references:
    
    - Version Dockerfiles generated from `images.json`
    - Pin Dockerfiles created from version tags
    - Updated `digests.json` with latest image references
    
    ### Commits
    
    ```
    967173a5 chore: update digests.json with latest image references
    ```
    
    This PR will be automatically merged by Mergify if all checks pass.